### PR TITLE
Pages created by the Diagram app should use the plain syntax

### DIFF
--- a/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -51,7 +51,7 @@
     #set ($discard = $response.writer.write($svg))
   #elseif ($xcontext.action == 'export')
     {{html clean="false"}}
-    &lt;img src="$doc.getURL('get', 'data=svg')" alt="$escapetool.xml($doc.plainTitle)" /&gt;
+    &lt;img src="$doc.getURL('get', "data=svg&amp;v=$!doc.version")" alt="$escapetool.xml($doc.plainTitle)" /&gt;
     {{/html}}
   #else
     #set ($discard = $xwiki.ssx.use('Diagram.DiagramViewSheet'))


### PR DESCRIPTION
In order to stop links normalizing to XWiki 2.1 syntax.