### PR TITLE
#18: Create a migration script for diagrams affected by #11

### DIFF
--- a/src/main/resources/Diagram/MigrationScript.xml
+++ b/src/main/resources/Diagram/MigrationScript.xml
@@ -39,44 +39,30 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
-  <content>{{velocity}}
+  <content>{{include reference="Diagram.MigrationScriptMacros"/}}
 
-#macro(selectDiagramsRequiringMigration)
-  #set ($repository = $services.extension.getRepository('installed'))
-  #set ($extension = $services.extension.installed.getInstalledExtension('org.xwiki.contrib:draw.io', "wiki:$xcontext.database"))
-  #if ($extension != $NULL)
-    #set ($targetVersion = $extension.version)
-  #end
-  #if ($targetVersion)
-    #set ($migrationIsRequiredClause = " and doc.content like '%draw.io%' and doc.content not like '%draw.io/$targetVersion/%'")
-    #set ($hql = "select doc.fullName from XWikiDocument as doc, BaseObject as obj where obj.name = doc.fullName and obj.className='Diagram.DiagramClass' and doc.fullName &lt;&gt; 'Diagram.DiagramTemplate' $migrationIsRequiredClause")
-    #set ($toBeMigratedEntries = $services.query.hql($hql).execute())
-  #end
-#end
+{{velocity}}
 
-## Display the content below only if the page is not included by another one.
-#if ($doc.name == 'MigrationScript')
-  {{info}}
+{{info}}
   This page contains a script for migrating diagram pages after an upgrade of the diagram application. It will update the paths containing the version of the draw.io library with the version currently used by the application. The script is a temporary solution until the bug //[[Paths to images inserted into diagrams become invalid at upgrade&gt;&gt;https://github.com/xwikisas/application-diagram/issues/11]]// gets fixed.
   {{html clean="false"}}
     &lt;form action="" method="post"&gt;
     &lt;input class="btn btn-default" type="submit" name="execute" value="Execute"/&gt;
     &lt;input type="hidden" name="form_token" value="$!{services.csrf.token}" /&gt;
     &lt;/form&gt;
-  {{/html}}
+{{/html}}
 
-  {{/info}}
+{{/info}}
 
   == Diagrams requiring a migration ==
 
-  #selectDiagramsRequiringMigration()
   {{info}}
   #if (!$targetVersion)
    No version of draw.io was found, please make sure that the Diagram Application is installed (either [[pro&gt;&gt;https://store.xwiki.com/xwiki/bin/view/Extension/DiagramApplication]] or [[non-pro&gt;&gt;https://extensions.xwiki.org/xwiki/bin/view/Extension/Diagram%20Application]] version).
   #else
     The target draw.io version found is : $targetVersion.
   #end
-  {{/info}}
+{{/info}}
 
   #if ($targetVersion)
     #set ($columnsProperties = {
@@ -91,8 +77,7 @@
       'translationPrefix': 'diagram.livetable.',
       'tagCloud': true,
       'rowCount': 15,
-      'maxPages': 10,
-      'extraParams': "migrationIsRequiredClause=$escapetool.url($migrationIsRequiredClause)"
+      'maxPages': 10
     })
     #set ($columns = ['doc.location', 'doc.date', 'doc.author', '_actions'])
     #livetable('diagrams-to-be-migrated' $columns $columnsProperties $options)
@@ -111,47 +96,5 @@
       #end
     #end
   #end
-#end
-{{/velocity}}
-
-</content>
-  <object>
-    <name>Diagram.MigrationScript</name>
-    <number>0</number>
-    <className>XWiki.RequiredRightClass</className>
-    <guid>930a64c2-31f3-4b02-93b7-df84b7d2fe34</guid>
-    <class>
-      <name>XWiki.RequiredRightClass</name>
-      <customClass/>
-      <customMapping/>
-      <defaultViewSheet/>
-      <defaultEditSheet/>
-      <defaultWeb/>
-      <nameField/>
-      <validationScript/>
-      <level>
-        <cache>0</cache>
-        <disabled>0</disabled>
-        <displayType>select</displayType>
-        <multiSelect>0</multiSelect>
-        <name>level</name>
-        <number>1</number>
-        <picker>0</picker>
-        <prettyName>level</prettyName>
-        <relationalStorage>0</relationalStorage>
-        <separator> </separator>
-        <separators> ,|</separators>
-        <size>1</size>
-        <sort>none</sort>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <values>edit|programming</values>
-        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
-      </level>
-    </class>
-    <property>
-      <level>programming</level>
-    </property>
-  </object>
+{{/velocity}}</content>
 </xwikidoc>

--- a/src/main/resources/Diagram/MigrationScript.xml
+++ b/src/main/resources/Diagram/MigrationScript.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <!--
  * See the NOTICE file distributed with this work for additional
  * information regarding copyright ownership.
@@ -38,70 +39,82 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
-  <content>{{info}}
-This page contains a script for migrating diagram pages after an upgrade of the diagram application to the pro version of the application. It will update the paths containing the version of the draw.io library with the version currently used by the application.
+  <content>{{velocity}}
 
-{{html}}
-  &lt;form action="" method="post"&gt;
-  &lt;input class="btn btn-default" type="submit" name="preview" value="Preview"/&gt;
-  &lt;input class="btn btn-default" type="submit" name="execute" value="Execute"/&gt;
-  &lt;/form&gt;
-{{/html}}
+#macro(selectDiagramsRequiringMigration)
+  #set ($repository = $services.extension.getRepository('installed'))
+  #set ($extension = $services.extension.installed.getInstalledExtension('org.xwiki.contrib:draw.io', "wiki:$xcontext.database"))
+  #if ($extension != $NULL)
+    #set ($targetVersion = $extension.version)
+  #end
+  #if ($targetVersion)
+    #set ($migrationIsRequiredClause = " and doc.content like '%draw.io%' and doc.content not like '%draw.io/$targetVersion/%'")
+    #set ($hql = "select doc.fullName from XWikiDocument as doc, BaseObject as obj where obj.name = doc.fullName and obj.className='Diagram.DiagramClass' and doc.fullName &lt;&gt; 'Diagram.DiagramTemplate' $migrationIsRequiredClause")
+    #set ($toBeMigratedEntries = $services.query.hql($hql).execute())
+  #end
+#end
 
-{{/info}}
+## Display the content below only if the page is not included by another one.
+#if ($doc.name == 'MigrationScript')
+  {{info}}
+  This page contains a script for migrating diagram pages after an upgrade of the diagram application. It will update the paths containing the version of the draw.io library with the version currently used by the application. The script is a temporary solution until the bug //[[Paths to images inserted into diagrams become invalid at upgrade&gt;&gt;https://github.com/xwikisas/application-diagram/issues/11]]// gets fixed.
+  {{html clean="false"}}
+    &lt;form action="" method="post"&gt;
+    &lt;input class="btn btn-default" type="submit" name="execute" value="Execute"/&gt;
+    &lt;input type="hidden" name="form_token" value="$!{services.csrf.token}" /&gt;
+    &lt;/form&gt;
+  {{/html}}
 
-{{groovy}}
-  
+  {{/info}}
 
-String getDependencyVersion(String extensionId, String dependencyId) {
+  == Diagrams requiring a migration ==
 
-  def extensionManager = services.extension
-  def repository = extensionManager.getRepository('installed')
+  #selectDiagramsRequiringMigration()
+  {{info}}
+  #if (!$targetVersion)
+   No version of draw.io was found, please make sure that the Diagram Application is installed (either [[pro&gt;&gt;https://store.xwiki.com/xwiki/bin/view/Extension/DiagramApplication]] or [[non-pro&gt;&gt;https://extensions.xwiki.org/xwiki/bin/view/Extension/Diagram%20Application]] version).
+  #else
+    The target draw.io version found is : $targetVersion.
+  #end
+  {{/info}}
 
-  def extensions = services.extension.installed.getInstalledExtensions()
-  for (extension in extensions) {
-    if ("$extension.id".indexOf(extensionId) == 0) {
-      for (dependency in extension.dependencies) {
-        if (dependency.id.indexOf(dependencyId) == 0) {
-          return dependency.versionConstraint
-        }
-      }
-    }
-  }
-  return "No version found, make sure the extension $extensionId is installed."
-}
+  #if ($targetVersion)
+    #set ($columnsProperties = {
+      'doc.location': {"type":"text","size":20,"html":true},
+      'doc.date': {"type":"text","size":10},
+      'doc.author': {"type":"text","size":10,"link":"author"},
+      '_actions': {"sortable":false,"filterable":false,"html":true,"actions":["edit","delete"]}
+    })
+    #set ($options = {
+      'className': 'Diagram.DiagramClass',
+      'resultPage': 'Diagram.MigrationScriptLiveTableResults',
+      'translationPrefix': 'diagram.livetable.',
+      'tagCloud': true,
+      'rowCount': 15,
+      'maxPages': 10,
+      'extraParams': "migrationIsRequiredClause=$escapetool.url($migrationIsRequiredClause)"
+    })
+    #set ($columns = ['doc.location', 'doc.date', 'doc.author', '_actions'])
+    #livetable('diagrams-to-be-migrated' $columns $columnsProperties $options)
 
-if (request.preview || request.execute) {
-  def targetVersion = getDependencyVersion("com.xwiki.diagram:application-diagram", "org.xwiki.contrib:draw.io")
+    #if (("$!request.execute" != '') &amp;&amp; $services.csrf.isTokenValid($request.getParameter("form_token")))
+      == Migration ==
 
-  println "The target draw.io version found is : $targetVersion."
+     |=Diagram|=Migration note
+      #foreach ($entry in $toBeMigratedEntries)
+        #set ($page = $xwiki.getDocument($entry))
+        #set ($content = $page.content)
+        #set ($migratedContent = $content.replaceAll('draw\.io\/([^\/]*)\/img', "draw.io/$targetVersion/img"))
+        #set ($discard = $page.setContent($migratedContent))
+        #set ($discard = $page.save("Migration to draw.io $targetVersion"))
+        |[[$entry]]|Diagram was migrated to draw.io $targetVersion.
+      #end
+    #end
+  #end
+#end
+{{/velocity}}
 
-  def hql = "select doc.fullName from XWikiDocument as doc, BaseObject as obj where obj.name = doc.fullName and obj.className='Diagram.DiagramClass' and doc.fullName &lt;&gt; 'Diagram.DiagramTemplate'"
-
-  def entries = services.query.hql(hql).execute()
-
-  println "|=Page name|=Migration"
-  
-  for (entry in entries) {
-    if (request.execute) {
-      def page = xwiki.getDocument(entry)
-      def migratedContent = page.content.replaceAll(/draw\.io\/([^\/]*)\/img/) { all, version -&gt; 
-        "draw.io/$targetVersion/img" 
-      }
-      if (migratedContent != page.content) {
-        page.setContent(migratedContent)
-        page.save("Migration to draw.io $targetVersion")
-        println "|[[$entry]]|Page was migrated to draw.io $targetVersion"
-      } else {
-        println "|[[$entry]]|No migration was needed."
-      }
-    } else {
-      println "|[[$entry]]|Page will get migrated to draw.io $targetVersion."
-    }
-  }
-}
-  
-{{/groovy}}</content>
+</content>
   <object>
     <name>Diagram.MigrationScript</name>
     <number>0</number>

--- a/src/main/resources/Diagram/MigrationScript.xml
+++ b/src/main/resources/Diagram/MigrationScript.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.3" reference="Diagram.MigrationScript" locale="">
+  <web>Diagram</web>
+  <name>MigrationScript</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <creationDate>1549541592000</creationDate>
+  <parent>xwiki:Diagram.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <date>1549541642000</date>
+  <contentUpdateDate>1549541592000</contentUpdateDate>
+  <version>1.1</version>
+  <title>MigrationScript</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content>{{info}}
+This page contains a script for migrating diagram pages after an upgrade of the diagram application to the pro version of the application. It will update the paths containing the version of the draw.io library with the version currently used by the application.
+
+{{html}}
+  &lt;form action="" method="post"&gt;
+  &lt;input class="btn btn-default" type="submit" name="preview" value="Preview"/&gt;
+  &lt;input class="btn btn-default" type="submit" name="execute" value="Execute"/&gt;
+  &lt;/form&gt;
+{{/html}}
+
+{{/info}}
+
+{{groovy}}
+  
+
+String getDependencyVersion(String extensionId, String dependencyId) {
+
+  def extensionManager = services.extension
+  def repository = extensionManager.getRepository('installed')
+
+  def extensions = services.extension.installed.getInstalledExtensions()
+  for (extension in extensions) {
+    if ("$extension.id".indexOf(extensionId) == 0) {
+      for (dependency in extension.dependencies) {
+        if (dependency.id.indexOf(dependencyId) == 0) {
+          return dependency.versionConstraint
+        }
+      }
+    }
+  }
+  return "No version found, make sure the extension $extensionId is installed."
+}
+
+if (request.preview || request.execute) {
+  def targetVersion = getDependencyVersion("com.xwiki.diagram:application-diagram", "org.xwiki.contrib:draw.io")
+
+  println "The target draw.io version found is : $targetVersion."
+
+  def hql = "select doc.fullName from XWikiDocument as doc, BaseObject as obj where obj.name = doc.fullName and obj.className='Diagram.DiagramClass' and doc.fullName &lt;&gt; 'Diagram.DiagramTemplate'"
+
+  def entries = services.query.hql(hql).execute()
+
+  println "|=Page name|=Migration"
+  
+  for (entry in entries) {
+    if (request.execute) {
+      def page = xwiki.getDocument(entry)
+      def migratedContent = page.content.replaceAll(/draw\.io\/([^\/]*)\/img/) { all, version -&gt; 
+        "draw.io/$targetVersion/img" 
+      }
+      if (migratedContent != page.content) {
+        page.setContent(migratedContent)
+        page.save("Migration to draw.io $targetVersion")
+        println "|[[$entry]]|Page was migrated to draw.io $targetVersion"
+      } else {
+        println "|[[$entry]]|No migration was needed."
+      }
+    } else {
+      println "|[[$entry]]|Page will get migrated to draw.io $targetVersion."
+    }
+  }
+}
+  
+{{/groovy}}</content>
+  <object>
+    <name>Diagram.MigrationScript</name>
+    <number>0</number>
+    <className>XWiki.RequiredRightClass</className>
+    <guid>930a64c2-31f3-4b02-93b7-df84b7d2fe34</guid>
+    <class>
+      <name>XWiki.RequiredRightClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <level>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>level</name>
+        <number>1</number>
+        <picker>0</picker>
+        <prettyName>level</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators> ,|</separators>
+        <size>1</size>
+        <sort>none</sort>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <values>edit|programming</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </level>
+    </class>
+    <property>
+      <level>programming</level>
+    </property>
+  </object>
+</xwikidoc>

--- a/src/main/resources/Diagram/MigrationScriptLiveTableResults.xml
+++ b/src/main/resources/Diagram/MigrationScriptLiveTableResults.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.3" reference="Diagram.MigrationScriptLiveTableResults" locale="">
+  <web>Diagram</web>
+  <name>MigrationScriptLiveTableResults</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <creationDate>1550509033000</creationDate>
+  <parent>WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <date>1550573605000</date>
+  <contentUpdateDate>1550573605000</contentUpdateDate>
+  <version>1.1</version>
+  <title>MigrationScriptLiveTableResults</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content>{{include reference="XWiki.LiveTableResultsMacros" /}}
+
+{{velocity}}
+#set ($extra = "$!request.migrationIsRequiredClause")
+#gridresultwithfilter("$!request.classname" $request.collist.split(',') '' "${extra}" $params)
+{{/velocity}}</content>
+</xwikidoc>

--- a/src/main/resources/Diagram/MigrationScriptMacros.xml
+++ b/src/main/resources/Diagram/MigrationScriptMacros.xml
@@ -20,29 +20,40 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.3" reference="Diagram.MigrationScriptLiveTableResults" locale="">
+<xwikidoc version="1.3" reference="Diagram.MigrationScriptMacros" locale="">
   <web>Diagram</web>
-  <name>MigrationScriptLiveTableResults</name>
+  <name>MigrationScriptMacros</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
   <creator>xwiki:XWiki.Admin</creator>
-  <creationDate>1550509033000</creationDate>
-  <parent>WebHome</parent>
+  <creationDate>1550662704000</creationDate>
+  <parent>Diagram.MigrationScript</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1550573605000</date>
-  <contentUpdateDate>1550573605000</contentUpdateDate>
+  <date>1550662942000</date>
+  <contentUpdateDate>1550662942000</contentUpdateDate>
   <version>1.1</version>
-  <title>MigrationScriptLiveTableResults</title>
+  <title>MigrationScriptMacros</title>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
-  <content>{{include reference="XWiki.LiveTableResultsMacros" /}}
-{{include reference="Diagram.MigrationScriptMacros" /}}
+  <content>{{velocity output="false"}}
 
-{{velocity}}
-#gridresultwithfilter("$!request.classname" $request.collist.split(',') '' "${migrationIsRequiredClause}" $params)
+#macro(selectDiagramsRequiringMigration)
+  #set ($repository = $services.extension.getRepository('installed'))
+  #set ($extension = $services.extension.installed.getInstalledExtension('org.xwiki.contrib:draw.io', "wiki:$xcontext.database"))
+  #if ($extension != $NULL)
+    #set ($targetVersion = $extension.version)
+  #end
+  #if ($targetVersion)
+    #set ($migrationIsRequiredClause = " and doc.content like '%draw.io%' and doc.content not like '%draw.io/$targetVersion/%'")
+    #set ($hql = "select doc.fullName from XWikiDocument as doc, BaseObject as obj where obj.name = doc.fullName and obj.className='Diagram.DiagramClass' and doc.fullName &lt;&gt; 'Diagram.DiagramTemplate' $migrationIsRequiredClause")
+    #set ($toBeMigratedEntries = $services.query.hql($hql).execute())
+  #end
+#end
+
+#selectDiagramsRequiringMigration()
 {{/velocity}}</content>
 </xwikidoc>

--- a/src/main/resources/Diagram/WebHome.xml
+++ b/src/main/resources/Diagram/WebHome.xml
@@ -40,7 +40,7 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>false</hidden>
   <content>{{include reference="Licenses.Code.VelocityMacros"/}}
-{{include reference="Diagram.MigrationScript"/}}
+{{include reference="Diagram.MigrationScriptMacros"/}}
 
 {{velocity output="false"}}
 #macro (diagramLiveTable)
@@ -66,7 +66,6 @@
 {{velocity}}
 #set ($diagramClassReference = $services.model.createDocumentReference('', 'Diagram', 'DiagramClass'))
 #if ($services.licensing.licensor.hasLicensureForEntity($diagramClassReference))
-  #selectDiagramsRequiringMigration()
   #if ($toBeMigratedEntries &amp;&amp; $toBeMigratedEntries.size() &gt; 0)
     {{warning}}
     You have $toBeMigratedEntries.size() diagrams to be migrated. Please click [[here&gt;&gt;MigrationScript]] to proceed.

--- a/src/main/resources/Diagram/WebHome.xml
+++ b/src/main/resources/Diagram/WebHome.xml
@@ -40,6 +40,7 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>false</hidden>
   <content>{{include reference="Licenses.Code.VelocityMacros"/}}
+{{include reference="Diagram.MigrationScript"/}}
 
 {{velocity output="false"}}
 #macro (diagramLiveTable)
@@ -65,6 +66,13 @@
 {{velocity}}
 #set ($diagramClassReference = $services.model.createDocumentReference('', 'Diagram', 'DiagramClass'))
 #if ($services.licensing.licensor.hasLicensureForEntity($diagramClassReference))
+  #selectDiagramsRequiringMigration()
+  #if ($toBeMigratedEntries &amp;&amp; $toBeMigratedEntries.size() &gt; 0)
+    {{warning}}
+    You have $toBeMigratedEntries.size() diagrams to be migrated. Please click [[here&gt;&gt;MigrationScript]] to proceed.
+    {{/warning}}
+  #end
+
   #diagramLiveTable
 #else
   {{error}}#getMissingLicenseMessage('diagram.extension.name'){{/error}}


### PR DESCRIPTION
Here's a migration script that will replace the old draw.io version to the one installed in the current wiki. Will work only for the pro version (the pro extension id is currently hard coded in the script).