### PR TITLE
#34: Migration script: execute only if there is a valid license

### DIFF
--- a/src/main/resources/Diagram/DiagramTranslations.fr.xml
+++ b/src/main/resources/Diagram/DiagramTranslations.fr.xml
@@ -57,19 +57,19 @@ diagram.livetable.doc.location=Emplacement
 diagram.livetable.emptyvalue=-
 
 # Diagram Macro
-rendering.macro.diagram.description=Affiche un diagramme.
+rendering.macro.diagram.description=Affiche une diagramme.
 rendering.macro.diagram.name=Diagramme
-rendering.macro.diagram.parameter.cached.description=Afficher le diagramme sous la forme d'une image mise en cache (plus rapide) plutôt que d'un dessin vectoriel (plus lent).
-rendering.macro.diagram.parameter.cached.name=Mise en cache
-rendering.macro.diagram.parameter.reference.description=rendering.macro.diagram.parameter.reference.description=La référence vers la page qui contient le diagramme à afficher. Ex : pour "http:~/~/.../Diagram/Mon%20Diagramme/", saisir "Diagram.Mon Diagramme.WebHome". Si ce champ est laissé vide, la macro recherche une page descendante nommée "Diagramme" et, en cas d'absence, affiche un formulaire de création de diagramme.
-rendering.macro.diagram.parameter.reference.name=Référence
-diagram.macro.create=Créer un diagramme
-diagram.macro.createNotAllowed=Vous n'êtes pas autorisé(e) à créer ce diagramme.
-diagram.macro.edit=Modifier le diagramme
-diagram.macro.invalidReference=La page spécifiée n'est pas un diagramme.
-diagram.macro.view=Voir le diagramme
-diagram.macro.viewNotAllowed=Vous n'êtes pas autorisé(e) à voir ce diagramme.
+rendering.macro.diagram.parameter.cached.description=Afficher une image d'une diagramme cachée (plus rapide) au lieu de rendre la diagramme en live (plus lent).
+rendering.macro.diagram.parameter.cached.name=Caché
+rendering.macro.diagram.parameter.reference.description=rendering.macro.diagram.parameter.reference.description=La référence vers la page qui contient la diagramme à afficher. Ex. pour "http:~/~/.../Diagram/My%20Diagram/", rentrez "Diagram.My Diagram.WebHome". Si ce champ est laissé vide, la macro cherche pour une page-enfant nommée "Diagramme" et, si pas trouvée, affiche un formulaire qui permet la création d'une diagramme.
+rendering.macro.diagram.parameter.reference.name=Reférence
+diagram.macro.create=Créer diagramme
+diagram.macro.createNotAllowed=Vous n'êtes pas autorisé à créer cette diagramme.
+diagram.macro.edit=Modifier diagramme
+diagram.macro.invalidReference=La page spécifiée n'est pas une diagramme.
+diagram.macro.view=Voir diagramme
+diagram.macro.viewNotAllowed=Vous n'êtes pas autorisé à voir cette diagramme.
 
 # Diagram editor
-diagram.editor.saveAsImageAttachmentError=Erreur à l'enregistrement du diagramme comme un attachement.</content>
+diagram.editor.saveAsImageAttachmentError=Erreur à l'enregistrement du diagramme comme une attachement.</content>
 </xwikidoc>

--- a/src/main/resources/Diagram/DiagramTranslations.fr.xml
+++ b/src/main/resources/Diagram/DiagramTranslations.fr.xml
@@ -57,16 +57,16 @@ diagram.livetable.doc.location=Emplacement
 diagram.livetable.emptyvalue=-
 
 # Diagram Macro
-rendering.macro.diagram.description=Affiche une diagramme.
+rendering.macro.diagram.description=Affiche un diagramme.
 rendering.macro.diagram.name=Diagramme
-rendering.macro.diagram.parameter.cached.description=Afficher une image d'une diagramme cachée (plus rapide) au lieu de rendre la diagramme en live (plus lent).
-rendering.macro.diagram.parameter.cached.name=Caché
-rendering.macro.diagram.parameter.reference.description=rendering.macro.diagram.parameter.reference.description=La référence vers la page qui contient la diagramme à afficher. Ex. pour "http:~/~/.../Diagram/My%20Diagram/", rentrez "Diagram.My Diagram.WebHome". Si ce champ est laissé vide, la macro cherche pour une page-enfant nommée "Diagramme" et, si pas trouvée, affiche un formulaire qui permet la création d'une diagramme.
-rendering.macro.diagram.parameter.reference.name=Reférence
-diagram.macro.create=Créer diagramme
-diagram.macro.createNotAllowed=Vous n'êtes pas autorisé à créer cette diagramme.
-diagram.macro.edit=Modifier diagramme
-diagram.macro.invalidReference=La page spécifiée n'est pas une diagramme.
-diagram.macro.view=Voir diagramme
-diagram.macro.viewNotAllowed=Vous n'êtes pas autorisé à voir cette diagramme.</content>
+rendering.macro.diagram.parameter.cached.description=Afficher le diagramme sous la forme d'une image mise en cache (plus rapide) plutôt que d'un dessin vectoriel (plus lent).
+rendering.macro.diagram.parameter.cached.name=Mise en cache
+rendering.macro.diagram.parameter.reference.description=rendering.macro.diagram.parameter.reference.description=La référence vers la page qui contient le diagramme à afficher. Ex : pour "http:~/~/.../Diagram/Mon%20Diagramme/", saisir "Diagram.Mon Diagramme.WebHome". Si ce champ est laissé vide, la macro recherche une page descendante nommée "Diagramme" et, en cas d'absence, affiche un formulaire de création de diagramme.
+rendering.macro.diagram.parameter.reference.name=Référence
+diagram.macro.create=Créer un diagramme
+diagram.macro.createNotAllowed=Vous n'êtes pas autorisé(e) à créer ce diagramme.
+diagram.macro.edit=Modifier le diagramme
+diagram.macro.invalidReference=La page spécifiée n'est pas un diagramme.
+diagram.macro.view=Voir le diagramme
+diagram.macro.viewNotAllowed=Vous n'êtes pas autorisé(e) à voir ce diagramme.</content>
 </xwikidoc>

--- a/src/main/resources/Diagram/DiagramTranslations.xml
+++ b/src/main/resources/Diagram/DiagramTranslations.xml
@@ -71,7 +71,10 @@ diagram.macro.view=View diagram
 diagram.macro.viewNotAllowed=You are not allowed to view this diagram.
 
 # Diagram editor
-diagram.editor.saveAsImageAttachmentError=Error when saving the diagram as an image attachment.</content>
+diagram.editor.saveAsImageAttachmentError=Error when saving the diagram as an image attachment.
+
+# Diagram migrator
+diagram.migration.warning={0} {0,choice,1#diagram requires|1&lt;diagrams require} a migration. Please click {1}here{2} to proceed.</content>
   <object>
     <name>Diagram.DiagramTranslations</name>
     <number>0</number>

--- a/src/main/resources/Diagram/MigrationScript.xml
+++ b/src/main/resources/Diagram/MigrationScript.xml
@@ -34,37 +34,29 @@
   <date>1549541642000</date>
   <contentUpdateDate>1549541592000</contentUpdateDate>
   <version>1.1</version>
-  <title>MigrationScript</title>
+  <title>Diagram Migration Utility</title>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
-  <content>{{include reference="Diagram.MigrationScriptMacros"/}}
+  <content>{{include reference="Licenses.Code.VelocityMacros"/}}
+{{include reference="Diagram.MigrationScriptMacros"/}}
 
 {{velocity}}
-
-{{info}}
-  This page contains a script for migrating diagram pages after an upgrade of the diagram application. It will update the paths containing the version of the draw.io library with the version currently used by the application. The script is a temporary solution until the bug //[[Paths to images inserted into diagrams become invalid at upgrade&gt;&gt;https://github.com/xwikisas/application-diagram/issues/11]]// gets fixed.
-  {{html clean="false"}}
-    &lt;form action="" method="post"&gt;
-    &lt;input class="btn btn-default" type="submit" name="execute" value="Execute"/&gt;
-    &lt;input type="hidden" name="form_token" value="$!{services.csrf.token}" /&gt;
-    &lt;/form&gt;
-{{/html}}
-
-{{/info}}
+#checkLicensureForDiagramApplication()
+#if ($hasLicensureForDiagramApplication)
+  #selectDiagramsRequiringMigration()
+  {{info}}
+  This page contains a script for migrating diagram pages after an upgrade of the Diagram Application Pro, or an upgrade from the non-pro version to the pro one. It will update the paths containing the version of the draw.io library with the version currently used by the application. The script is a temporary solution until the bug //[[Paths to images inserted into diagrams become invalid at upgrade&gt;&gt;https://github.com/xwikisas/application-diagram/issues/11]]// gets fixed.
+  {{/info}}
 
   == Diagrams requiring a migration ==
 
-  {{info}}
   #if (!$targetVersion)
-   No version of draw.io was found, please make sure that the Diagram Application is installed (either [[pro&gt;&gt;https://store.xwiki.com/xwiki/bin/view/Extension/DiagramApplication]] or [[non-pro&gt;&gt;https://extensions.xwiki.org/xwiki/bin/view/Extension/Diagram%20Application]] version).
+    {{warning}}
+     No version of draw.io was found, please make sure that [[Diagram Application Pro&gt;&gt;https://store.xwiki.com/xwiki/bin/view/Extension/DiagramApplication]] is installed.
+    {{/warning}}
   #else
-    The target draw.io version found is : $targetVersion.
-  #end
-{{/info}}
-
-  #if ($targetVersion)
     #set ($columnsProperties = {
       'doc.location': {"type":"text","size":20,"html":true},
       'doc.date': {"type":"text","size":10},
@@ -82,8 +74,8 @@
     #set ($columns = ['doc.location', 'doc.date', 'doc.author', '_actions'])
     #livetable('diagrams-to-be-migrated' $columns $columnsProperties $options)
 
-    #if (("$!request.execute" != '') &amp;&amp; $services.csrf.isTokenValid($request.getParameter("form_token")))
-      == Migration ==
+    #if (("$!request.action" == 'migrate') &amp;&amp; $services.csrf.isTokenValid($request.getParameter("form_token")))
+      == Migration results ==
 
      |=Diagram|=Migration note
       #foreach ($entry in $toBeMigratedEntries)
@@ -94,7 +86,17 @@
         #set ($discard = $page.save("Migration to draw.io $targetVersion"))
         |[[$entry]]|Diagram was migrated to draw.io $targetVersion.
       #end
+    #elseif ($toBeMigratedEntries &amp;&amp; $toBeMigratedEntries.size() &gt; 0)
+      {{html clean="false"}}
+      &lt;form action="" method="post"&gt;
+        &lt;button class="btn btn-default" type="submit" name="action" value="migrate"&gt;Proceed with the migration&lt;/button&gt;
+        &lt;input type="hidden" name="form_token" value="$!{services.csrf.token}" /&gt;
+      &lt;/form&gt;
+      {{/html}}
     #end
   #end
+#else
+  {{error}}#getMissingLicenseMessage('diagram.extension.name'){{/error}}
+#end
 {{/velocity}}</content>
 </xwikidoc>

--- a/src/main/resources/Diagram/MigrationScript.xml
+++ b/src/main/resources/Diagram/MigrationScript.xml
@@ -43,60 +43,56 @@
 {{include reference="Diagram.MigrationScriptMacros"/}}
 
 {{velocity}}
-#checkLicensureForDiagramApplication()
-#if ($hasLicensureForDiagramApplication)
-  #selectDiagramsRequiringMigration()
-  {{info}}
-  This page contains a script for migrating diagram pages after an upgrade of the Diagram Application Pro, or an upgrade from the non-pro version to the pro one. It will update the paths containing the version of the draw.io library with the version currently used by the application. The script is a temporary solution until the bug //[[Paths to images inserted into diagrams become invalid at upgrade&gt;&gt;https://github.com/xwikisas/application-diagram/issues/11]]// gets fixed.
-  {{/info}}
+#selectDiagramsRequiringMigration()
 
-  == Diagrams requiring a migration ==
+{{info}}
+This page contains a script for migrating diagram pages after an upgrade of the Diagram Application Pro, or an upgrade from the non-pro version to the pro one. It will update the paths containing the version of the draw.io library with the version currently used by the application. The script is a temporary solution until the bug //[[Paths to images inserted into diagrams become invalid at upgrade&gt;&gt;https://github.com/xwikisas/application-diagram/issues/11]]// gets fixed.
+{{/info}}
 
-  #if (!$targetVersion)
-    {{warning}}
-     No version of draw.io was found, please make sure that [[Diagram Application Pro&gt;&gt;https://store.xwiki.com/xwiki/bin/view/Extension/DiagramApplication]] is installed.
-    {{/warning}}
-  #else
-    #set ($columnsProperties = {
-      'doc.location': {"type":"text","size":20,"html":true},
-      'doc.date': {"type":"text","size":10},
-      'doc.author': {"type":"text","size":10,"link":"author"},
-      '_actions': {"sortable":false,"filterable":false,"html":true,"actions":["edit","delete"]}
-    })
-    #set ($options = {
-      'className': 'Diagram.DiagramClass',
-      'resultPage': 'Diagram.MigrationScriptLiveTableResults',
-      'translationPrefix': 'diagram.livetable.',
-      'tagCloud': true,
-      'rowCount': 15,
-      'maxPages': 10
-    })
-    #set ($columns = ['doc.location', 'doc.date', 'doc.author', '_actions'])
-    #livetable('diagrams-to-be-migrated' $columns $columnsProperties $options)
+== Diagrams requiring a migration ==
 
-    #if (("$!request.action" == 'migrate') &amp;&amp; $services.csrf.isTokenValid($request.getParameter("form_token")))
-      == Migration results ==
-
-     |=Diagram|=Migration note
-      #foreach ($entry in $toBeMigratedEntries)
-        #set ($page = $xwiki.getDocument($entry))
-        #set ($content = $page.content)
-        #set ($migratedContent = $content.replaceAll('draw\.io\/([^\/]*)\/img', "draw.io/$targetVersion/img"))
-        #set ($discard = $page.setContent($migratedContent))
-        #set ($discard = $page.save("Migration to draw.io $targetVersion"))
-        |[[$entry]]|Diagram was migrated to draw.io $targetVersion.
-      #end
-    #elseif ($toBeMigratedEntries &amp;&amp; $toBeMigratedEntries.size() &gt; 0)
-      {{html clean="false"}}
-      &lt;form action="" method="post"&gt;
-        &lt;button class="btn btn-default" type="submit" name="action" value="migrate"&gt;Proceed with the migration&lt;/button&gt;
-        &lt;input type="hidden" name="form_token" value="$!{services.csrf.token}" /&gt;
-      &lt;/form&gt;
-      {{/html}}
-    #end
-  #end
+#if (!$targetVersion)
+  {{warning}}
+   No version of draw.io was found, please make sure that [[Diagram Application Pro&gt;&gt;https://store.xwiki.com/xwiki/bin/view/Extension/DiagramApplication]] is installed.
+  {{/warning}}
 #else
-  {{error}}#getMissingLicenseMessage('diagram.extension.name'){{/error}}
+  #set ($columnsProperties = {
+    'doc.location': {"type":"text","size":20,"html":true},
+    'doc.date': {"type":"text","size":10},
+    'doc.author': {"type":"text","size":10,"link":"author"},
+    '_actions': {"sortable":false,"filterable":false,"html":true,"actions":["edit","delete"]}
+  })
+  #set ($options = {
+    'className': 'Diagram.DiagramClass',
+    'resultPage': 'Diagram.MigrationScriptLiveTableResults',
+    'translationPrefix': 'diagram.livetable.',
+    'tagCloud': true,
+    'rowCount': 15,
+    'maxPages': 10
+  })
+  #set ($columns = ['doc.location', 'doc.date', 'doc.author', '_actions'])
+  #livetable('diagrams-to-be-migrated' $columns $columnsProperties $options)
+
+  #if (("$!request.action" == 'migrate') &amp;&amp; $services.csrf.isTokenValid($request.getParameter("form_token")))
+    == Migration results ==
+
+   |=Diagram|=Migration note
+    #foreach ($entry in $toBeMigratedEntries)
+      #set ($page = $xwiki.getDocument($entry))
+      #set ($content = $page.content)
+      #set ($migratedContent = $content.replaceAll('draw\.io\/([^\/]*)\/img', "draw.io/$targetVersion/img"))
+      #set ($discard = $page.setContent($migratedContent))
+      #set ($discard = $page.save("Migration to draw.io $targetVersion"))
+      |[[$entry]]|Diagram was migrated to draw.io $targetVersion.
+    #end
+  #elseif ($toBeMigratedEntries &amp;&amp; $toBeMigratedEntries.size() &gt; 0)
+    {{html clean="false"}}
+    &lt;form action="" method="post"&gt;
+      &lt;button class="btn btn-default" type="submit" name="action" value="migrate"&gt;Proceed with the migration&lt;/button&gt;
+      &lt;input type="hidden" name="form_token" value="$!{services.csrf.token}" /&gt;
+    &lt;/form&gt;
+    {{/html}}
+  #end
 #end
 {{/velocity}}</content>
 </xwikidoc>

--- a/src/main/resources/Diagram/MigrationScript.xml
+++ b/src/main/resources/Diagram/MigrationScript.xml
@@ -39,8 +39,7 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
-  <content>{{include reference="Licenses.Code.VelocityMacros"/}}
-{{include reference="Diagram.MigrationScriptMacros"/}}
+  <content>{{include reference="Diagram.MigrationScriptMacros"/}}
 
 {{velocity}}
 #selectDiagramsRequiringMigration()

--- a/src/main/resources/Diagram/MigrationScriptLiveTableResults.xml
+++ b/src/main/resources/Diagram/MigrationScriptLiveTableResults.xml
@@ -39,10 +39,14 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
-  <content>{{include reference="XWiki.LiveTableResultsMacros" /}}
-{{include reference="Diagram.MigrationScriptMacros" /}}
+  <content>{{include reference="XWiki.LiveTableResultsMacros"/}}
+{{include reference="Diagram.MigrationScriptMacros"/}}
 
 {{velocity}}
-#gridresultwithfilter("$!request.classname" $request.collist.split(',') '' "${migrationIsRequiredClause}" $params)
+#checkLicensureForDiagramApplication()
+#if ($hasLicensureForDiagramApplication)
+  #selectDiagramsRequiringMigration()
+  #gridresultwithfilter("$!request.classname" $request.collist.split(',') '' "${migrationIsRequiredClause}" $params)
+#end
 {{/velocity}}</content>
 </xwikidoc>

--- a/src/main/resources/Diagram/MigrationScriptLiveTableResults.xml
+++ b/src/main/resources/Diagram/MigrationScriptLiveTableResults.xml
@@ -43,10 +43,7 @@
 {{include reference="Diagram.MigrationScriptMacros"/}}
 
 {{velocity}}
-#checkLicensureForDiagramApplication()
-#if ($hasLicensureForDiagramApplication)
-  #selectDiagramsRequiringMigration()
-  #gridresultwithfilter("$!request.classname" $request.collist.split(',') '' "${migrationIsRequiredClause}" $params)
-#end
+#selectDiagramsRequiringMigration()
+#gridresultwithfilter("$!request.classname" $request.collist.split(',') '' "${migrationIsRequiredClause}" $params)
 {{/velocity}}</content>
 </xwikidoc>

--- a/src/main/resources/Diagram/MigrationScriptMacros.xml
+++ b/src/main/resources/Diagram/MigrationScriptMacros.xml
@@ -40,8 +40,7 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity output="false"}}
-
-#macro(selectDiagramsRequiringMigration)
+#macro (selectDiagramsRequiringMigration)
   #set ($repository = $services.extension.getRepository('installed'))
   #set ($extension = $services.extension.installed.getInstalledExtension('org.xwiki.contrib:draw.io', "wiki:$xcontext.database"))
   #if ($extension != $NULL)
@@ -53,7 +52,5 @@
     #set ($toBeMigratedEntries = $services.query.hql($hql).execute())
   #end
 #end
-
-#selectDiagramsRequiringMigration()
 {{/velocity}}</content>
 </xwikidoc>

--- a/src/main/resources/Diagram/MigrationScriptMacros.xml
+++ b/src/main/resources/Diagram/MigrationScriptMacros.xml
@@ -40,6 +40,10 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity output="false"}}
+#macro (checkLicensureForDiagramApplication)
+  #set ($diagramClassReference = $services.model.createDocumentReference('', 'Diagram', 'DiagramClass'))
+  #set ($hasLicensureForDiagramApplication = $services.licensing.licensor.hasLicensureForEntity($diagramClassReference))
+#end
 #macro (selectDiagramsRequiringMigration)
   #set ($repository = $services.extension.getRepository('installed'))
   #set ($extension = $services.extension.installed.getInstalledExtension('org.xwiki.contrib:draw.io', "wiki:$xcontext.database"))

--- a/src/main/resources/Diagram/MigrationScriptMacros.xml
+++ b/src/main/resources/Diagram/MigrationScriptMacros.xml
@@ -40,10 +40,6 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity output="false"}}
-#macro (checkLicensureForDiagramApplication)
-  #set ($diagramClassReference = $services.model.createDocumentReference('', 'Diagram', 'DiagramClass'))
-  #set ($hasLicensureForDiagramApplication = $services.licensing.licensor.hasLicensureForEntity($diagramClassReference))
-#end
 #macro (selectDiagramsRequiringMigration)
   #set ($repository = $services.extension.getRepository('installed'))
   #set ($extension = $services.extension.installed.getInstalledExtension('org.xwiki.contrib:draw.io', "wiki:$xcontext.database"))

--- a/src/main/resources/Diagram/WebHome.xml
+++ b/src/main/resources/Diagram/WebHome.xml
@@ -41,7 +41,8 @@
   <hidden>false</hidden>
   <content>{{include reference="Licenses.Code.VelocityMacros"/}}
 {{velocity}}
-#if ($services.licensing.licensor.hasLicensureForEntity($services.model.createDocumentReference('', 'Diagram', 'DiagramClass')))
+#if ($services.licensing.licensor.hasLicensureForEntity(
+    $services.model.createDocumentReference('', 'Diagram', 'DiagramClass')))
   {{include reference="Diagram.MigrationScriptMacros"/}}
 #end
 {{/velocity}}

--- a/src/main/resources/Diagram/WebHome.xml
+++ b/src/main/resources/Diagram/WebHome.xml
@@ -69,7 +69,8 @@
 {{/velocity}}
 
 {{velocity}}
-#if ($services.licensing.licensor.hasLicensureForEntity($services.model.createDocumentReference('', 'Diagram', 'DiagramClass')))
+#if ($services.licensing.licensor.hasLicensureForEntity(
+    $services.model.createDocumentReference('', 'Diagram', 'DiagramClass')))
   #selectDiagramsRequiringMigration()
   #if ($toBeMigratedEntries &amp;&amp; $toBeMigratedEntries.size() &gt; 0)
     #if ($toBeMigratedEntries.size() &gt; 1)#set ($label = 'diagrams require')#else#set ($label = 'diagram requires')#end

--- a/src/main/resources/Diagram/WebHome.xml
+++ b/src/main/resources/Diagram/WebHome.xml
@@ -75,7 +75,9 @@
   #if ($toBeMigratedEntries &amp;&amp; $toBeMigratedEntries.size() &gt; 0)
     #if ($toBeMigratedEntries.size() &gt; 1)#set ($label = 'diagrams require')#else#set ($label = 'diagram requires')#end
     {{warning}}
-    $toBeMigratedEntries.size() $label a migration. Please click [[here&gt;&gt;MigrationScript]] to proceed.
+    {{html clean="false"}}
+    $services.localization.render("diagram.migration.warning", [$toBeMigratedEntries.size(), "&lt;a href='$xwiki.getURL('Diagram.MigrationScript')'&gt;", '&lt;/a&gt;'])
+    {{/html}}
     {{/warning}}
   #end
   #diagramLiveTable

--- a/src/main/resources/Diagram/WebHome.xml
+++ b/src/main/resources/Diagram/WebHome.xml
@@ -73,7 +73,6 @@
     $services.model.createDocumentReference('', 'Diagram', 'DiagramClass')))
   #selectDiagramsRequiringMigration()
   #if ($toBeMigratedEntries &amp;&amp; $toBeMigratedEntries.size() &gt; 0)
-    #if ($toBeMigratedEntries.size() &gt; 1)#set ($label = 'diagrams require')#else#set ($label = 'diagram requires')#end
     {{warning}}
     {{html clean="false"}}
     $services.localization.render("diagram.migration.warning", [$toBeMigratedEntries.size(), "&lt;a href='$xwiki.getURL('Diagram.MigrationScript')'&gt;", '&lt;/a&gt;'])

--- a/src/main/resources/Diagram/WebHome.xml
+++ b/src/main/resources/Diagram/WebHome.xml
@@ -40,6 +40,7 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>false</hidden>
   <content>{{include reference="Licenses.Code.VelocityMacros"/}}
+{{include reference="Diagram.MigrationScriptMacros"/}}
 
 {{velocity output="false"}}
 #macro (diagramLiveTable)
@@ -63,16 +64,15 @@
 {{/velocity}}
 
 {{velocity}}
-#set ($diagramClassReference = $services.model.createDocumentReference('', 'Diagram', 'DiagramClass'))
-#if ($services.licensing.licensor.hasLicensureForEntity($diagramClassReference))
-  #includeMacros('Diagram.MigrationScriptMacros')
-  #selectDiagramsRequiringMigration
+#checkLicensureForDiagramApplication()
+#if ($hasLicensureForDiagramApplication)
+  #selectDiagramsRequiringMigration()
   #if ($toBeMigratedEntries &amp;&amp; $toBeMigratedEntries.size() &gt; 0)
+    #if ($toBeMigratedEntries.size() &gt; 1)#set ($diagramLabel = 'diagrams')#else#set ($diagramLabel = 'diagram')#end
     {{warning}}
-    You have $toBeMigratedEntries.size() diagrams to be migrated. Please click [[here&gt;&gt;MigrationScript]] to proceed.
+    $toBeMigratedEntries.size() $diagramLabel requires a migration. Please click [[here&gt;&gt;MigrationScript]] to proceed.
     {{/warning}}
   #end
-
   #diagramLiveTable
 #else
   {{error}}#getMissingLicenseMessage('diagram.extension.name'){{/error}}

--- a/src/main/resources/Diagram/WebHome.xml
+++ b/src/main/resources/Diagram/WebHome.xml
@@ -40,7 +40,6 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>false</hidden>
   <content>{{include reference="Licenses.Code.VelocityMacros"/}}
-{{include reference="Diagram.MigrationScriptMacros"/}}
 
 {{velocity output="false"}}
 #macro (diagramLiveTable)
@@ -66,6 +65,8 @@
 {{velocity}}
 #set ($diagramClassReference = $services.model.createDocumentReference('', 'Diagram', 'DiagramClass'))
 #if ($services.licensing.licensor.hasLicensureForEntity($diagramClassReference))
+  #includeMacros('Diagram.MigrationScriptMacros')
+  #selectDiagramsRequiringMigration
   #if ($toBeMigratedEntries &amp;&amp; $toBeMigratedEntries.size() &gt; 0)
     {{warning}}
     You have $toBeMigratedEntries.size() diagrams to be migrated. Please click [[here&gt;&gt;MigrationScript]] to proceed.

--- a/src/main/resources/Diagram/WebHome.xml
+++ b/src/main/resources/Diagram/WebHome.xml
@@ -40,7 +40,11 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>false</hidden>
   <content>{{include reference="Licenses.Code.VelocityMacros"/}}
-{{include reference="Diagram.MigrationScriptMacros"/}}
+{{velocity}}
+#if ($services.licensing.licensor.hasLicensureForEntity($services.model.createDocumentReference('', 'Diagram', 'DiagramClass')))
+  {{include reference="Diagram.MigrationScriptMacros"/}}
+#end
+{{/velocity}}
 
 {{velocity output="false"}}
 #macro (diagramLiveTable)
@@ -64,13 +68,12 @@
 {{/velocity}}
 
 {{velocity}}
-#checkLicensureForDiagramApplication()
-#if ($hasLicensureForDiagramApplication)
+#if ($services.licensing.licensor.hasLicensureForEntity($services.model.createDocumentReference('', 'Diagram', 'DiagramClass')))
   #selectDiagramsRequiringMigration()
   #if ($toBeMigratedEntries &amp;&amp; $toBeMigratedEntries.size() &gt; 0)
-    #if ($toBeMigratedEntries.size() &gt; 1)#set ($diagramLabel = 'diagrams')#else#set ($diagramLabel = 'diagram')#end
+    #if ($toBeMigratedEntries.size() &gt; 1)#set ($label = 'diagrams require')#else#set ($label = 'diagram requires')#end
     {{warning}}
-    $toBeMigratedEntries.size() $diagramLabel requires a migration. Please click [[here&gt;&gt;MigrationScript]] to proceed.
+    $toBeMigratedEntries.size() $label a migration. Please click [[here&gt;&gt;MigrationScript]] to proceed.
     {{/warning}}
   #end
   #diagramLiveTable


### PR DESCRIPTION
- Move the migration script call to a block executed only if there is a valid license
- Move the migration macro call to Diagram.WebHome so that Diagram.MigrationScriptMacros contains macro definition only
- Change slightly the formatting