### PR TITLE
#37: The link to a Diagram text is not saved in view mode if you don't click outside the text element before saving the Diagram page

### DIFF
--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -377,6 +377,9 @@ define('diagramStore', ['jquery', 'draw.io', 'xwiki-events-bridge'], function($)
 
   var updateFormFields = function(event) {
     forEachOpenedFile(function(file) {
+      // This is a workaround for https://github.com/jgraph/drawio/issues/490
+      // Stop editing for getting the latest content from diagram
+      file.ui.editor.graph.stopEditing(false);
       file.updateFileData();
     });
   };


### PR DESCRIPTION
Workaround for solve non updated content of the diagram before saving the page.

The link to a Diagram text is not saved in view mode if you don't click outside the text element before saving the Diagram page #37