### PR TITLE
Store images as attachment #33

### DIFF
--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -706,7 +706,6 @@ define('diagramStore', ['jquery', 'xwiki-meta', 'draw.io', 'xwiki-events-bridge'
         let currentFile = files[0];
         diagramStore.uploadFile(currentFile, currentFile.name).done(function() {
           let doc = new XWiki.Document();
-          let documentReference = xm.documentReference;
           let xwikiURL = doc.getURL('download') + (doc.page == 'WebHome' ? doc.page : '') + '/' + currentFile.name;
           fn.apply(this, [xwikiURL, mimeType, x, y, w, h]);
         });

--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -707,7 +707,6 @@ define('diagramStore', ['jquery', 'xwiki-meta', 'draw.io', 'xwiki-events-bridge'
         diagramStore.uploadFile(currentFile, currentFile.name).done(function() {
           let doc = new XWiki.Document();
           let documentReference = xm.documentReference;
-          let attachmentReference = new XWiki.AttachmentReference(currentFile.name, documentReference);
           let xwikiURL = doc.getURL('download') + (doc.page == 'WebHome' ? doc.page : '') + '/' + currentFile.name;
           fn.apply(this, [xwikiURL, mimeType, x, y, w, h]);
         });

--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -523,7 +523,16 @@ define('diagramStore', ['jquery', 'draw.io', 'xwiki-events-bridge'], function($)
       <cache>long</cache>
     </property>
     <property>
-      <code>define('diagramEditor', ['jquery', 'diagramStore'], function($, diagramStore) {
+      <code>define('diagramEditor', ['jquery', 'diagramStore', 'xwiki-meta'], function($, diagramStore, xm) {
+
+  /* These variables are used to decide if an image should be uploaded at original resolution or
+   * should be declined for being too big.
+   *
+   * Default values:
+   * EditorUi.prototype.maxImageSize = 520;
+   * EditorUi.prototype.maxImageBytes = 1000000;
+   */
+
   //
   // Diagram Editor Constructor.
   //
@@ -618,6 +627,40 @@ define('diagramStore', ['jquery', 'draw.io', 'xwiki-events-bridge'], function($)
     };
     return converter;
   };
+
+  // Override for uploading the image as attachment instead of encode it to Base64
+  var oldImportFiles = EditorUi.prototype.importFiles;
+  EditorUi.prototype.importFiles = function(files, x, y, maxSize, fn, resultFn, filterFn, barrierFn, resizeDialog,
+                                             maxBytes, resampleThreshold, ignoreEmbeddedXml) {
+    var newArgs = Array.prototype.slice.call(arguments);
+    newArgs[4] = function(data, mimeType, x, y, w, h) {
+      if (data.substring(0, 5) == 'data:') {
+        var saveAttachment  = function(file) {
+          let doc = new XWiki.Document();
+          let url = doc.getURL('upload');
+          let formData = new FormData();
+          formData.append('filepath', file);
+          formData.append('form_token', xm.form_token);
+          $.post({
+            url: url,
+            data: formData,
+            processData: false,
+            contentType: false,
+            success : function() {
+              let documentReference = xm.documentReference;
+              let attachmentReference = new XWiki.AttachmentReference(file.name, documentReference);
+              let xwikiURL = doc.getURL('download') + (doc.page == 'WebHome' ? doc.page : '') + '/' + file.name;
+              fn.apply(this, [xwikiURL, mimeType, x, y, w, h]);
+            }
+          });
+        };
+        saveAttachment(files[0]);
+      } else {
+        fn.apply(this, arguments);
+      }
+    }
+    oldImportFiles.apply(this, newArgs);
+  }
 
   //
   // Fix the side bar tool tip: the tool tip position is computed as if the editor takes the full screen.

--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -592,7 +592,7 @@ define('diagramStore', ['jquery', 'xwiki-meta', 'draw.io', 'xwiki-events-bridge'
       <cache>long</cache>
     </property>
     <property>
-      <code>define('diagramEditor', ['jquery', 'diagramStore', 'xwiki-meta'], function($, diagramStore, xm) {
+      <code>define('diagramEditor', ['jquery', 'diagramStore'], function($, diagramStore, xm) {
 
   /* These variables are used to decide if an image should be uploaded at original resolution or
    * should be declined for being too big.

--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -596,11 +596,10 @@ define('diagramStore', ['jquery', 'xwiki-meta', 'draw.io', 'xwiki-events-bridge'
 
   /* These variables are used to decide if an image should be uploaded at original resolution or
    * should be declined for being too big.
-   *
-   * Default values:
-   * EditorUi.prototype.maxImageSize = 520;
-   * EditorUi.prototype.maxImageBytes = 1000000;
    */
+  // Default values:
+  // EditorUi.prototype.maxImageSize = 520;
+  // EditorUi.prototype.maxImageBytes = 1000000;
 
   //
   // Diagram Editor Constructor.
@@ -704,26 +703,15 @@ define('diagramStore', ['jquery', 'xwiki-meta', 'draw.io', 'xwiki-events-bridge'
     var newArgs = Array.prototype.slice.call(arguments);
     newArgs[4] = function(data, mimeType, x, y, w, h) {
       if (data.substring(0, 5) == 'data:') {
-        var saveAttachment  = function(file) {
+        let currentFile = files[0];
+        diagramStore.uploadFile(currentFile, currentFile.name).done(function() {
           let doc = new XWiki.Document();
-          let url = doc.getURL('upload');
-          let formData = new FormData();
-          formData.append('filepath', file);
-          formData.append('form_token', xm.form_token);
-          $.post({
-            url: url,
-            data: formData,
-            processData: false,
-            contentType: false,
-            success : function() {
-              let documentReference = xm.documentReference;
-              let attachmentReference = new XWiki.AttachmentReference(file.name, documentReference);
-              let xwikiURL = doc.getURL('download') + (doc.page == 'WebHome' ? doc.page : '') + '/' + file.name;
-              fn.apply(this, [xwikiURL, mimeType, x, y, w, h]);
-            }
-          });
-        };
-        saveAttachment(files[0]);
+          let documentReference = xm.documentReference;
+          let attachmentReference = new XWiki.AttachmentReference(currentFile.name, documentReference);
+          let xwikiURL = doc.getURL('download') + (doc.page == 'WebHome' ? doc.page : '') + '/' + currentFile.name;
+          fn.apply(this, [xwikiURL, mimeType, x, y, w, h]);
+        });
+        diagramStore.uploadFile(currentFile, currentFile.name);
       } else {
         fn.apply(this, arguments);
       }

--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -594,9 +594,8 @@ define('diagramStore', ['jquery', 'xwiki-meta', 'draw.io', 'xwiki-events-bridge'
     <property>
       <code>define('diagramEditor', ['jquery', 'diagramStore'], function($, diagramStore, xm) {
 
-  /* These variables are used to decide if an image should be uploaded at original resolution or
-   * should be declined for being too big.
-   */
+  // These variables are used to decide if an image should be uploaded at original resolution or
+  // should be declined for being too big.
   // Default values:
   // EditorUi.prototype.maxImageSize = 520;
   // EditorUi.prototype.maxImageBytes = 1000000;
@@ -705,11 +704,10 @@ define('diagramStore', ['jquery', 'xwiki-meta', 'draw.io', 'xwiki-events-bridge'
       if (data.substring(0, 5) == 'data:') {
         let currentFile = files[0];
         diagramStore.uploadFile(currentFile, currentFile.name).done(function() {
-          let doc = new XWiki.Document();
+          let doc = XWiki.currentDocument;
           let xwikiURL = doc.getURL('download') + (doc.page == 'WebHome' ? doc.page : '') + '/' + currentFile.name;
           fn.apply(this, [xwikiURL, mimeType, x, y, w, h]);
         });
-        diagramStore.uploadFile(currentFile, currentFile.name);
       } else {
         fn.apply(this, arguments);
       }

--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -592,7 +592,7 @@ define('diagramStore', ['jquery', 'xwiki-meta', 'draw.io', 'xwiki-events-bridge'
       <cache>long</cache>
     </property>
     <property>
-      <code>define('diagramEditor', ['jquery', 'diagramStore'], function($, diagramStore, xm) {
+      <code>define('diagramEditor', ['jquery', 'diagramStore'], function($, diagramStore) {
 
   // These variables are used to decide if an image should be uploaded at original resolution or
   // should be declined for being too big.


### PR DESCRIPTION
When the user selects an image, it will be uploaded as attachment & will be used as URL for the image.

Also, it's a fix for #9.