### PR TITLE
Saving the diagram takes to long after several changes made #49

### DIFF
--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -343,7 +343,8 @@ define('xwiki-utils', ['jquery', 'xwiki-meta'], function($, xm) {
 /**
  * Adds support for editing diagrams stored in XWiki pages.
  */
-define('diagramStore', ['jquery', 'xwiki-meta', 'xwiki-utils', 'draw.io', 'xwiki-events-bridge'], function($, xm, xutils) {
+define('diagramStore', ['jquery', 'xwiki-meta', 'xwiki-utils', 'draw.io', 'xwiki-events-bridge'],
+    function($, xm, xutils) {
   var files = [];
   window._xfiles = files;
   var createFile = function(ui, input, title) {

--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -326,12 +326,16 @@ define('spin-global', ['spin'], function(spin) {
 define('xwiki-utils', ['jquery', 'xwiki-meta'], function($, xm) {
   var getAttachmentURL = function(attachment, action, queryString) {
     var docRef = xm.documentReference;
-    if (typeof attachment != 'string') {
+    if (typeof attachment !== 'string') {
       docRef = attachment.parent;
       attachment = attachment.name;
     }
-    var attachmentURL = new XWiki.Document(docRef).getURL(action) + (docRef.name == 'WebHome' ? docRef.name : '') +
-      '/' + attachment + (queryString ? queryString : '');
+    if (typeof queryString === 'object') {
+      queryString = $.param(queryString);
+    }
+    var attachmentURL = new XWiki.Document(docRef).getURL(action || 'download') +
+      (docRef.name == 'WebHome' ? docRef.name : '') + '/' + attachment +
+      (queryString ? '?' + queryString : '');
     return attachmentURL;
   };
 
@@ -433,11 +437,10 @@ define('diagramStore', ['jquery', 'xwiki-meta', 'xwiki-utils', 'draw.io', 'xwiki
   };
 
   var deleteFile = function(fileName) {
-    var deferred = $.Deferred();
-    var doc = new XWiki.Document(xm.documentReference);
-    var queryString = '?form_token=' + xm.form_token + '&amp;xredirect=' +
-        encodeURIComponent(doc.getURL('get', 'outputSyntax=plain'));
-    var attachmentURL = xutils.getAttachmentURL(fileName, 'delattachment', queryString);
+    var attachmentURL = xutils.getAttachmentURL(fileName, 'delattachment', {
+      'form_token': xm.form_token,
+      'xredirect': XWiki.currentDocument.getURL('get', 'outputSyntax=plain')
+    });
     return $.post(attachmentURL);
   };
 
@@ -738,7 +741,7 @@ define('diagramStore', ['jquery', 'xwiki-meta', 'xwiki-utils', 'draw.io', 'xwiki
         let currentFile = files[0];
         diagramStore.uploadFile(currentFile, currentFile.name).done(function() {
           let doc = XWiki.currentDocument;
-          let xwikiURL = xutils.getAttachmentURL(currentFile.name, 'download');
+          let xwikiURL = xutils.getAttachmentURL(currentFile.name);
           fn.apply(this, [xwikiURL, mimeType, x, y, w, h]);
         });
       } else {

--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -330,8 +330,8 @@ define('xwiki-utils', ['jquery', 'xwiki-meta'], function($, xm) {
       docRef = attachment.parent;
       attachment = attachment.name;
     }
-    var attachmentURL = new XWiki.Document(docRef).getURL(action) + (docRef.name == 'WebHome' ? docRef.name : '') + '/'
-      + attachment + (queryString ? queryString : '');
+    var attachmentURL = new XWiki.Document(docRef).getURL(action) + (docRef.name == 'WebHome' ? docRef.name : '') +
+      '/' + attachment + (queryString ? queryString : '');
     return attachmentURL;
   };
 

--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -321,9 +321,29 @@ define('spin-global', ['spin'], function(spin) {
     </property>
     <property>
       <code>/**
+ * Generic helper methods.
+ */
+define('xwiki-utils', ['jquery', 'xwiki-meta'], function($, xm) {
+  var getAttachmentURL = function(attachment, action, queryString) {
+    var docRef = xm.documentReference;
+    if (typeof attachment != 'string') {
+      docRef = attachment.parent;
+      attachment = attachment.name;
+    }
+    var attachmentURL = new XWiki.Document(docRef).getURL(action) + (docRef.name == 'WebHome' ? docRef.name : '') + '/'
+      + attachment + (queryString ? queryString : '');
+    return attachmentURL;
+  };
+
+  return {
+    getAttachmentURL: getAttachmentURL
+  };
+});
+
+/**
  * Adds support for editing diagrams stored in XWiki pages.
  */
-define('diagramStore', ['jquery', 'xwiki-meta', 'draw.io', 'xwiki-events-bridge'], function($, xm) {
+define('diagramStore', ['jquery', 'xwiki-meta', 'xwiki-utils', 'draw.io', 'xwiki-events-bridge'], function($, xm, xutils) {
   var files = [];
   window._xfiles = files;
   var createFile = function(ui, input, title) {
@@ -411,12 +431,24 @@ define('diagramStore', ['jquery', 'xwiki-meta', 'draw.io', 'xwiki-events-bridge'
     });
   };
 
+  var deleteFile = function(fileName) {
+    var deferred = $.Deferred();
+    var doc = new XWiki.Document(xm.documentReference);
+    var queryString = '?form_token=' + xm.form_token + '&amp;xredirect=' +
+        encodeURIComponent(doc.getURL('get', 'outputSyntax=plain'));
+    var attachmentURL = xutils.getAttachmentURL(fileName, 'delattachment', queryString);
+    return $.post(attachmentURL);
+  };
+
+  // Keep only the last version of the attachment.
   var saveCanvasAsAttachment = function(canvas) {
     var deferred = $.Deferred();
     canvas.toBlob(function(blob) {
       var docRef = xm.documentReference;
       var fileName = (docRef.name == 'WebHome' ? docRef.parent.name : docRef.name) + '.thumbnail.png';
-      pipeDeferred(uploadFile(blob, fileName), deferred);
+      deleteFile(fileName).always(function() {
+        pipeDeferred(uploadFile(blob, fileName), deferred);
+      });
     });
     return deferred.promise();
   };
@@ -592,7 +624,7 @@ define('diagramStore', ['jquery', 'xwiki-meta', 'draw.io', 'xwiki-events-bridge'
       <cache>long</cache>
     </property>
     <property>
-      <code>define('diagramEditor', ['jquery', 'diagramStore'], function($, diagramStore) {
+      <code>define('diagramEditor', ['jquery', 'diagramStore', 'xwiki-utils'], function($, diagramStore, xutils) {
 
   // These variables are used to decide if an image should be uploaded at original resolution or
   // should be declined for being too big.
@@ -695,7 +727,7 @@ define('diagramStore', ['jquery', 'xwiki-meta', 'draw.io', 'xwiki-events-bridge'
     return converter;
   };
 
-  // Override for uploading the image as attachment instead of encode it to Base64
+  // Override for uploading the image as attachment instead of encode it to Base64.
   var oldImportFiles = EditorUi.prototype.importFiles;
   EditorUi.prototype.importFiles = function(files, x, y, maxSize, fn, resultFn, filterFn, barrierFn, resizeDialog,
                                              maxBytes, resampleThreshold, ignoreEmbeddedXml) {
@@ -705,7 +737,7 @@ define('diagramStore', ['jquery', 'xwiki-meta', 'draw.io', 'xwiki-events-bridge'
         let currentFile = files[0];
         diagramStore.uploadFile(currentFile, currentFile.name).done(function() {
           let doc = XWiki.currentDocument;
-          let xwikiURL = doc.getURL('download') + (doc.page == 'WebHome' ? doc.page : '') + '/' + currentFile.name;
+          let xwikiURL = xutils.getAttachmentURL(currentFile.name, 'download');
           fn.apply(this, [xwikiURL, mimeType, x, y, w, h]);
         });
       } else {


### PR DESCRIPTION
* for not having too many versions, upload the attachment only after the delete of the existing one is finished, even if it was succeeded or not.
* an error could appear in the developer console if the attachment does not exists on the page, without altering the functionalities. From the client side you cannot check the existence of the attachment in a different way.