### PR TITLE
Issue #33:  Store images as attachment

### DIFF
--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -735,17 +735,20 @@ define('diagramStore', ['jquery', 'xwiki-meta', 'xwiki-utils', 'draw.io', 'xwiki
   var oldImportFiles = EditorUi.prototype.importFiles;
   EditorUi.prototype.importFiles = function(files, x, y, maxSize, fn, resultFn, filterFn, barrierFn, resizeDialog,
                                              maxBytes, resampleThreshold, ignoreEmbeddedXml) {
-    var newArgs = Array.prototype.slice.call(arguments);
-    newArgs[4] = function(data, mimeType, x, y, w, h) {
-      if (data.substring(0, 5) == 'data:') {
-        let currentFile = files[0];
-        diagramStore.uploadFile(currentFile, currentFile.name).done(function() {
-          let doc = XWiki.currentDocument;
-          let xwikiURL = xutils.getAttachmentURL(currentFile.name);
-          fn.apply(this, [xwikiURL, mimeType, x, y, w, h]);
-        });
-      } else {
-        fn.apply(this, arguments);
+    var newArgs = arguments;
+    if (fn) {
+      var newArgs = Array.prototype.slice.call(arguments);
+      newArgs[4] = function(data, mimeType, x, y, w, h) {
+        if (data.substring(0, 5) == 'data:') {
+          let currentFile = files[0];
+          diagramStore.uploadFile(currentFile, currentFile.name).done(function() {
+            let doc = XWiki.currentDocument;
+            let xwikiURL = xutils.getAttachmentURL(currentFile.name);
+            fn.apply(this, [xwikiURL, mimeType, x, y, w, h]);
+          });
+        } else {
+          fn.apply(this, arguments);
+        }
       }
     }
     oldImportFiles.apply(this, newArgs);


### PR DESCRIPTION
Seems like in #46 we overrided the callback function without making checkings for a null value (which is used when importing files from the device).