### PR TITLE
Issue#55: The link generated by export as URL doesn't contain '//' after protocol

### DIFF
--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -773,7 +773,7 @@ define('diagramStore', ['jquery', 'xwiki-meta', 'xwiki-utils', 'draw.io', 'xwiki
       }
       // Append source parameter to the query
       queryString += '&amp;source=url';
-      return window.location.protocol + window.location.host +
+      return window.location.protocol + '//' + window.location.host +
         new XWiki.Document('DiagramViewSheet', 'Diagram').getURL('view', queryString, documentFragment);
     }
     return rawURL;


### PR DESCRIPTION
Added missing symbols