### PR TITLE
Issue #26: Can't import a diagram from browser

### DIFF
--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -670,6 +670,17 @@ define('diagramStore', ['jquery', 'xwiki-meta', 'xwiki-utils', 'draw.io', 'xwiki
   };
 
   //
+  // Add support for not displaying 'browser' option from 'Import from' sub-menu
+  //
+  var originalAddItem = mxPopupMenu.prototype.addItem;
+  mxPopupMenu.prototype.addItem = function(title, image, funct, parent, iconCls, enabled, active) {
+    if (title === (mxResources.get('browser') + '...') &amp;&amp; parent &amp;&amp; parent.innerText === 'Import from') {
+      return null;
+    }
+    return originalAddItem.apply(this, arguments);
+  };
+
+  //
   // Hide the editor footer.
   //
   var hideFooter = function(editorUI) {


### PR DESCRIPTION
Hide the `browser` option from `Import from` sub-menu since an option for exporting a diagram to the browser doesn't exist.