### PR TITLE
Sometimes an error message appears when saving the diagram #59

### DIFF
--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -450,31 +450,22 @@ define('diagramStore', ['jquery', 'xwiki-meta', 'xwiki-utils', 'draw.io', 'xwiki
     return $.post(attachmentURL);
   };
 
-  // Keep only the last version of the attachment.
-  var saveCanvasAsAttachment = function(canvas) {
+  var saveSvgAsAttachment = function(svg) {
     var deferred = $.Deferred();
-    canvas.toBlob(function(blob) {
-      var docRef = xm.documentReference;
-      var fileName = (docRef.name == 'WebHome' ? docRef.parent.name : docRef.name) + '.thumbnail.png';
-      deleteFile(fileName).always(function() {
-        pipeDeferred(uploadFile(blob, fileName), deferred);
-      });
+    var blob = new Blob([svg], {type: 'image/svg+xml'});
+    var docRef = xm.documentReference;
+    var fileName = (docRef.name == 'WebHome' ? docRef.parent.name : docRef.name) + '.thumbnail.svg';
+    // Keep only the last version of the attachment.
+    deleteFile(fileName).always(function() {
+      pipeDeferred(uploadFile(blob, fileName), deferred);
     });
     return deferred.promise();
   };
 
   var saveFileAsImageAttachment = function(file) {
     var deferred = $.Deferred();
-    file.getUi().exportToCanvas(function(canvas) {
-      if (canvas) {
-        pipeDeferred(saveCanvasAsAttachment(canvas), deferred);
-      } else {
-        deferred.reject();
-      }
-    }, null, null, null, function(e) {
-      new XWiki.widgets.Notification(
-        $jsontool.serialize($services.localization.render('diagram.editor.saveAsImageAttachmentError')), 'error');
-    }, null, true);
+    var svg = mxUtils.getXml(file.getUi().editor.graph.getSvg());
+    pipeDeferred(saveSvgAsAttachment(svg), deferred);
     return deferred.promise();
   };
 

--- a/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -54,7 +54,7 @@
     #if ($fileName == 'WebHome')
       #set ($fileName = $doc.documentReference.lastSpaceReference.name)
     #end
-    #set ($fileName = "${fileName}.thumbnail.png")
+    #set ($fileName = "${fileName}.thumbnail.svg")
     #set ($diagramURL = $doc.getAttachmentURL($fileName, 'download', "v=$!doc.version"))
     ## Use the svg for export in case the attachment does not exists.
     #if (!$doc.getAttachment($fileName))


### PR DESCRIPTION
* create blob from svg instead of canvas, since canvas.toBlob is not supported in IE, Edge and Safari