### PR TITLE
Added try/catch block for decoding/decompressing a diagram

### DIFF
--- a/src/main/resources/Diagram/DiagramSheet.xml
+++ b/src/main/resources/Diagram/DiagramSheet.xml
@@ -143,10 +143,15 @@ define ('diagram-utils', ['jquery', 'mxgraph-common'], function($) {
     if (hashIndex &gt; -1) {
       // Exclude first 2 letters from hash (#R).
       let hash = url.substring(hashIndex+2);
-      let decodedData = decodeURIComponent(hash);
-      let graph = new Graph();
-      let rawDiagram = graph.decompress(decodedData);
-      return rawDiagram;
+      try {
+        let decodedData = decodeURIComponent(hash);
+        let graph = new Graph();
+        let rawDiagram = graph.decompress(decodedData);
+        return rawDiagram;
+      }
+      catch (e) {
+        console.error (e.stack)
+      }
     }
     return null;
   };

--- a/src/main/resources/Diagram/DiagramSheet.xml
+++ b/src/main/resources/Diagram/DiagramSheet.xml
@@ -148,8 +148,7 @@ define ('diagram-utils', ['jquery', 'mxgraph-common'], function($) {
         let graph = new Graph();
         let rawDiagram = graph.decompress(decodedData);
         return rawDiagram;
-      }
-      catch (e) {
+      } catch (e) {
         console.error (e.stack)
       }
     }


### PR DESCRIPTION
As @mflorea suggested in [a2812f4](https://github.com/xwikisas/application-diagram/commit/a2812f41087e600ac4ba79bad63489136cec1d42#r35051870), I added a try/catch block for the code that is responsible for decompressing/decoding a diagram.