### PR TITLE
Paths to images inserted into diagrams become invalid at upgrade #11

### DIFF
--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -422,7 +422,7 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
       // Also, we remove draw.io version from clipart paths for saving the relative links. This is needed as a fix for:
       // https://github.com/xwikisas/application-diagram/issues/11 .
       var graphXML = mxUtils.getPrettyXml(this.ui.editor.getGraphXml());
-      this.setData(graphXML.replace(/image=[\w=":./%';\=\+\-`]*\/img/g, 'image=/img'));
+      this.setData(graphXML.replace(/image=[\w/%.]*\/img/g, 'image=/img'));
     },
     open: function() {
       var graphXML = diagramUtils.addLibraryInfo(this.getData() || '&lt;mxGraphModel/&gt;');
@@ -551,7 +551,7 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
       if (svgInput.length &gt; 0) {
         var svgRoot = file.getUi().editor.graph.getSvg('#ffffff', true, false, false, null, true);
         // Have relative clipart paths inside the cached svg for not saving draw.io version as well.
-        svgInput.val(mxUtils.getXml(svgRoot).replace(/href=[\w=":./%';\=\+\-`]*\/img/g, 'href="/img'));
+        svgInput.val(mxUtils.getXml(svgRoot).replace(/href="[\w:/%.]*\/img/g, 'href="/img'));
       }
     });
   });

--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -402,18 +402,6 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
     this.title = title;
   };
 
-  // Removes draw.io version from clipart paths for saving the relative links. This is needed as a fix for:
-  // https://github.com/xwikisas/application-diagram/issues/11
-  var removeLibraryInfo = function(graph) {
-    var gCells = graph.model.cells;
-    for (var key in gCells) {
-      var cell = gCells[key];
-      if(cell.style != undefined) {
-        graph.getModel().cells[key].style = cell.style.replace(/image=[\w=":./%';\=\+\-`]*\/img/g, 'image=/img');
-      }
-    }
-  }
-
   mxUtils.extend(XWikiFile, DrawioFile);
 
   $.extend(XWikiFile.prototype, {
@@ -431,8 +419,10 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
     },
     updateFileData: function() {
       // We overwrite the base implementation because we don't want to support files that contain multiple diagrams.
-      removeLibraryInfo(this.ui.editor.graph);
-      this.setData(mxUtils.getPrettyXml(this.ui.editor.getGraphXml()));
+      // Also, we remove draw.io version from clipart paths for saving the relative links. This is needed as a fix for:
+      // https://github.com/xwikisas/application-diagram/issues/11 .
+      var graphXML = mxUtils.getPrettyXml(this.ui.editor.getGraphXml());
+      this.setData(graphXML.replace(/image=[\w=":./%';\=\+\-`]*\/img/g, 'image=/img'));
     },
     open: function() {
       var graphXML = diagramUtils.addLibraryInfo(this.getData() || '&lt;mxGraphModel/&gt;');

--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -386,8 +386,8 @@ define('xwiki-utils', ['jquery', 'xwiki-meta'], function($, xm) {
 /**
  * Adds support for editing diagrams stored in XWiki pages.
  */
-define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'draw.io', 'xwiki-events-bridge'],
-    function($, xm, xutils) {
+define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils', 'draw.io', 'xwiki-events-bridge'],
+    function($, xm, xutils, diagramUtils) {
   var files = [];
   window._xfiles = files;
   var createFile = function(ui, input, title) {
@@ -401,6 +401,18 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'draw.io', 'xwik
     this.input = input;
     this.title = title;
   };
+
+  // Removes draw.io version from clipart paths for saving the relative links. This is needed as a fix for:
+  // https://github.com/xwikisas/application-diagram/issues/11
+  var removeLibraryInfo = function(graph) {
+    var gCells = graph.model.cells;
+    for (var key in gCells) {
+      var cell = gCells[key];
+      if(cell.style != undefined) {
+        graph.getModel().cells[key].style = cell.style.replace(/image=[\w=":./%';\=\+\-`]*\/img/g, 'image=/img');
+      }
+    }
+  }
 
   mxUtils.extend(XWikiFile, DrawioFile);
 
@@ -419,10 +431,11 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'draw.io', 'xwik
     },
     updateFileData: function() {
       // We overwrite the base implementation because we don't want to support files that contain multiple diagrams.
+      removeLibraryInfo(this.ui.editor.graph);
       this.setData(mxUtils.getPrettyXml(this.ui.editor.getGraphXml()));
     },
     open: function() {
-      var graphXML = this.getData() || '&lt;mxGraphModel/&gt;';
+      var graphXML = diagramUtils.addLibraryInfo(this.getData() || '&lt;mxGraphModel/&gt;');
       this.ui.editor.setGraphXml(mxUtils.parseXml(graphXML).documentElement);
       this.changeListener = mxUtils.bind(this, function(sender, eventObject) {
         this.setModified(true);
@@ -547,7 +560,8 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'draw.io', 'xwik
       var svgInput = file.input.next('.diagram-svg');
       if (svgInput.length &gt; 0) {
         var svgRoot = file.getUi().editor.graph.getSvg('#ffffff', true, false, false, null, true);
-        svgInput.val(mxUtils.getXml(svgRoot));
+        // Have relative clipart paths inside the cached svg for not saving draw.io version as well.
+        svgInput.val(mxUtils.getXml(svgRoot).replace(/href=[\w=":./%';\=\+\-`]*\/img/g, 'href="/img'));
       }
     });
   });

--- a/src/main/resources/Diagram/DiagramSheet.xml
+++ b/src/main/resources/Diagram/DiagramSheet.xml
@@ -191,10 +191,19 @@ define ('diagram-utils', ['jquery', 'mxgraph-common'], function($) {
     return deferred.promise();
   };
 
+  // Adds draw.io version into clipart paths when editing or viewing a diagram, since the saved links are relative.
+  // This is needed as a fix for: https://github.com/xwikisas/application-diagram/issues/11
+  var addLibraryInfo = function(diagramXML) {
+    var newPrefix = 'image=' + "$services.webjars.url('org.xwiki.contrib:draw.io', '')" + '/img';
+    diagramXML = diagramXML.replace(/image=\/img/g, newPrefix);
+    return diagramXML;
+  }
+
   return {
     getDiagramXMLFromURL: getDiagramXMLFromURL,
     getParameterValueFromURL: getParameterValueFromURL,
-    loadTranslationAndTheme: loadTranslationAndTheme
+    loadTranslationAndTheme: loadTranslationAndTheme,
+    addLibraryInfo: addLibraryInfo
   };
 });</code>
     </property>
@@ -202,7 +211,7 @@ define ('diagram-utils', ['jquery', 'mxgraph-common'], function($) {
       <name>Diagram utils</name>
     </property>
     <property>
-      <parse>0</parse>
+      <parse>1</parse>
     </property>
     <property>
       <use>onDemand</use>

--- a/src/main/resources/Diagram/DiagramSheet.xml
+++ b/src/main/resources/Diagram/DiagramSheet.xml
@@ -197,7 +197,7 @@ define ('diagram-utils', ['jquery', 'mxgraph-common'], function($) {
     var newPrefix = 'image=' + "$services.webjars.url('org.xwiki.contrib:draw.io', '')" + '/img';
     diagramXML = diagramXML.replace(/image=\/img/g, newPrefix);
     return diagramXML;
-  }
+  };
 
   return {
     getDiagramXMLFromURL: getDiagramXMLFromURL,

--- a/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -58,6 +58,14 @@
     #set ($diagramURL = $doc.getAttachmentURL($fileName, 'download', "v=$!doc.version"))
     ## Use the svg for export in case the attachment does not exists.
     #if (!$doc.getAttachment($fileName))
+      ## Update clipart links inside svg since they are saved as relative ones.
+      #set ($obj = $doc.getObject('Diagram.DiagramClass'))
+      #set ($svg = $obj.getValue('svg'))
+      #set ($regex = 'href="\/img')
+      #set ($newPrefix = 'href="' + "$services.webjars.url('org.xwiki.contrib:draw.io', '')" + '/img')
+      #set ($svg = $svg.replaceAll($regex, $newPrefix))
+      #set ($discard = $obj.set('svg', $svg))
+      #set ($discard = $doc.save())
       #set ($diagramURL = $doc.getURL('get', "data=svg&amp;v=$!doc.version"))
     #end
     {{html clean="false"}}
@@ -373,7 +381,7 @@ define('spin-global', ['spin'], function(spin) {
 
   $.fn.viewDiagram = function(configOverride) {
     return this.each(function() {
-      var diagramXML = diagramUtils.getDiagramXMLFromURL(window.location.href) || $(this).data('model');
+      var diagramXML = diagramUtils.addLibraryInfo(diagramUtils.getDiagramXMLFromURL(window.location.href) || $(this).data('model'));
       var diagramRootNode = mxUtils.parseXml(diagramXML).documentElement;
       var config = $.extend(getDiagramViewerConfig($(this)), configOverride);
       var graphViewer = new GraphViewer(this, diagramRootNode, config);

--- a/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -43,10 +43,14 @@
 #if ($doc.getObject('Diagram.DiagramClass') || "$!request.source" != '')
   #if ($xcontext.action == 'get' &amp;&amp; $request.data == 'svg')
     #set ($svg = $doc.getValue('svg'))
+    #set ($regex = 'href="\/img')
+    #set ($newPrefix = 'href="' + "$services.webjars.url('org.xwiki.contrib:draw.io', '')" + '/img')
     #if ("$!svg" == '')
       #set ($svg = '&lt;svg/&gt;')
     #end
     #set ($discard = $response.setContentType('image/svg+xml'))
+    ## Update clipart links inside svg since they are saved as relative ones.
+    #set ($svg = $svg.replaceAll($regex, $newPrefix))
     #set ($discard = $response.setContentLength($svg.length()))
     #set ($discard = $response.writer.write($svg))
   #elseif ($xcontext.action == 'export' || $request.xpage == 'print')
@@ -58,14 +62,6 @@
     #set ($diagramURL = $doc.getAttachmentURL($fileName, 'download', "v=$!doc.version"))
     ## Use the svg for export in case the attachment does not exists.
     #if (!$doc.getAttachment($fileName))
-      ## Update clipart links inside svg since they are saved as relative ones.
-      #set ($obj = $doc.getObject('Diagram.DiagramClass'))
-      #set ($svg = $obj.getValue('svg'))
-      #set ($regex = 'href="\/img')
-      #set ($newPrefix = 'href="' + "$services.webjars.url('org.xwiki.contrib:draw.io', '')" + '/img')
-      #set ($svg = $svg.replaceAll($regex, $newPrefix))
-      #set ($discard = $obj.set('svg', $svg))
-      #set ($discard = $doc.save())
       #set ($diagramURL = $doc.getURL('get', "data=svg&amp;v=$!doc.version"))
     #end
     {{html clean="false"}}


### PR DESCRIPTION
* removes from the graph and the cached svg the information about draw.io at save action and adds it back only for view mode, export as pdf (when there is no attachment and the svg is used) and also when entering in edit mode