### PR TITLE
Add support for choosing between SVG-based and image-based PDF export…

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramClass.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramClass.xml
@@ -40,6 +40,31 @@
   <syntaxId>xwiki/2.0</syntaxId>
   <hidden>true</hidden>
   <content/>
+  <class>
+    <name>Diagram.DiagramClass</name>
+    <customClass/>
+    <customMapping/>
+    <defaultViewSheet/>
+    <defaultEditSheet/>
+    <defaultWeb/>
+    <nameField/>
+    <validationScript/>
+    <exportUsingSVG>
+      <customDisplay/>
+      <defaultValue>1</defaultValue>
+      <disabled>0</disabled>
+      <displayFormType>select</displayFormType>
+      <displayType/>
+      <hint/>
+      <name>exportUsingSVG</name>
+      <number>1</number>
+      <prettyName>exportUsingSVG</prettyName>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+    </exportUsingSVG>
+  </class>
   <object>
     <name>Diagram.DiagramClass</name>
     <number>0</number>

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -245,12 +245,36 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
     left.done($.proxy(right, 'resolve')).fail($.proxy(right, 'reject'));
   };
 
-  var imageCache = {};
-  var saveFileAsImageAttachment = function(file) {
+  var saveBlobAsImageAttachment = function(blob, fileName, documentReference) {
     var deferred = $.Deferred();
-    // This is a workaround for https://github.com/jgraph/drawio/issues/490
-    // Stop editing for getting the latest content from diagram
-    file.ui.editor.graph.stopEditing(false);
+    var attachmentReference = new XWiki.AttachmentReference(fileName, documentReference);
+    // Avoid creating too many versions of the attachment.
+    xutils.deleteAttachment(attachmentReference).always(function() {
+      pipeDeferred(xutils.uploadAttachment(blob, attachmentReference), deferred);
+    });
+    return deferred.promise();
+  };
+
+  var imageCache = {};
+  var saveFileAsPNGImageAttachment = function(file) {
+    var deferred = $.Deferred();
+    file.getUi().exportToCanvas(/* callback */ function(canvas) {
+      if (canvas) {
+        canvas.toBlob(function(blob) {
+          pipeDeferred(saveBlobAsImageAttachment(blob, 'diagram.thumbnail.png', file.documentReference), deferred);
+        });
+      } else {
+        deferred.reject();
+      }
+    }, /* width */ null, /* imageCache */ imageCache, /* background */ null, /* error */ function(e) {
+      new XWiki.widgets.Notification(
+        $jsontool.serialize($services.localization.render('diagram.editor.saveAsImageAttachmentError')), 'error');
+    }, /* limitHeight */ null, /* ignoreSelection */ true);
+    return deferred.promise();
+  };
+
+  var saveFileAsSVGImageAttachment = function(file) {
+    var deferred = $.Deferred();
     var svgRoot = file.ui.editor.graph.getSvg(/* background: */ '#ffffff', /* scale: */ null, /* border: */ null,
       /* nocrop: */ true, /* crisp: */ null, /* ignoreSelection: */ true);
     // Embed the images because the PDF exporter might not be able to access them.
@@ -259,19 +283,26 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
         '&lt;!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"&gt;\n' +
         mxUtils.getXml(svgRoot);
       var blob = new Blob([svg], {type: 'image/svg+xml'});
-      var attachmentReference = new XWiki.AttachmentReference('diagram.svg', file.documentReference);
-      // Avoid creating too many versions of the attachment.
-      xutils.deleteAttachment(attachmentReference).always(function() {
-        pipeDeferred(xutils.uploadAttachment(blob, attachmentReference), deferred);
-      });
+      pipeDeferred(saveBlobAsImageAttachment(blob, 'diagram.svg', file.documentReference), deferred);
     }, imageCache);
+    return deferred.promise();
+  };
+
+  var saveFileAsImageAttachments = function(file) {
+    var deferred = $.Deferred().resolve();
+    // This is a workaround for https://github.com/jgraph/drawio/issues/490
+    // Stop editing for getting the latest content from diagram
+    file.ui.editor.graph.stopEditing(false);
+    var svgUpload = $.proxy(saveFileAsSVGImageAttachment, null, file);
+    var pngUpload = $.proxy(saveFileAsPNGImageAttachment, null, file);
+    deferred = deferred.then(svgUpload, svgUpload).then(pngUpload, pngUpload);
     return deferred.promise();
   };
 
   var saveFilesAsImageAttachments = function() {
     var uploadDeferred = $.Deferred().resolve();
     forEachOpenedFile(function(file) {
-      var nextUpload = $.proxy(saveFileAsImageAttachment, null, file);
+      var nextUpload = $.proxy(saveFileAsImageAttachments, null, file);
       uploadDeferred = uploadDeferred.then(nextUpload, nextUpload);
     });
     return uploadDeferred.promise();

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -246,13 +246,10 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
   };
 
   var saveBlobAsImageAttachment = function(blob, fileName, documentReference) {
-    var deferred = $.Deferred();
     var attachmentReference = new XWiki.AttachmentReference(fileName, documentReference);
-    // Avoid creating too many versions of the attachment.
-    xutils.deleteAttachment(attachmentReference).always(function() {
-      pipeDeferred(xutils.uploadAttachment(blob, attachmentReference), deferred);
-    });
-    return deferred.promise();
+    var uploadAttachment = $.proxy(xutils.uploadAttachment, null, blob, attachmentReference);
+    // Avoid creating too many versions of the attachment. Upload the attachment even if we failed to delete it first.
+    return xutils.deleteAttachment(attachmentReference).then(uploadAttachment, uploadAttachment);
   };
 
   var imageCache = {};
@@ -261,7 +258,7 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
     file.getUi().exportToCanvas(/* callback */ function(canvas) {
       if (canvas) {
         canvas.toBlob(function(blob) {
-          pipeDeferred(saveBlobAsImageAttachment(blob, 'diagram.thumbnail.png', file.documentReference), deferred);
+          pipeDeferred(saveBlobAsImageAttachment(blob, 'diagram.png', file.documentReference), deferred);
         });
       } else {
         deferred.reject();
@@ -269,6 +266,7 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
     }, /* width */ null, /* imageCache */ imageCache, /* background */ null, /* error */ function(e) {
       new XWiki.widgets.Notification(
         $jsontool.serialize($services.localization.render('diagram.editor.saveAsImageAttachmentError')), 'error');
+      deferred.reject();
     }, /* limitHeight */ null, /* ignoreSelection */ true);
     return deferred.promise();
   };
@@ -289,19 +287,18 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
   };
 
   var saveFileAsImageAttachments = function(file) {
-    var deferred = $.Deferred().resolve();
     // This is a workaround for https://github.com/jgraph/drawio/issues/490
     // Stop editing for getting the latest content from diagram
     file.ui.editor.graph.stopEditing(false);
-    var svgUpload = $.proxy(saveFileAsSVGImageAttachment, null, file);
+    // We upload the PNG image even if the SVG upload has failed.
     var pngUpload = $.proxy(saveFileAsPNGImageAttachment, null, file);
-    deferred = deferred.then(svgUpload, svgUpload).then(pngUpload, pngUpload);
-    return deferred.promise();
+    return saveFileAsSVGImageAttachment(file).then(pngUpload, pngUpload);
   };
 
   var saveFilesAsImageAttachments = function() {
     var uploadDeferred = $.Deferred().resolve();
     forEachOpenedFile(function(file) {
+      // We do the next upload even if the previous uploads have failed.
       var nextUpload = $.proxy(saveFileAsImageAttachments, null, file);
       uploadDeferred = uploadDeferred.then(nextUpload, nextUpload);
     });

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
@@ -171,11 +171,10 @@
     #if ($diagramObj)
       #if ($xcontext.action == 'edit' || $xcontext.action == 'export' || $request.xpage == 'print'
           || $xcontext.macro.params.cached == 'true')
-        #set ($fileName = 'diagram.svg')
-        #set ($pngFileName = 'diagram.thumbnail.png')
-        #if ($xcontext.action == 'export' &amp;&amp; $diagramObj.getValue('exportUsingSVG') == 0
-            &amp;&amp; $diagram.getAttachment($pngFileName))
-          #set ($fileName = $pngFileName)
+        #set ($fileName = 'diagram.png')
+        #if ($xcontext.action != 'export' || $diagramObj.getValue('exportUsingSVG') == 1
+            || !$diagram.getAttachment($fileName))
+          #set ($fileName = 'diagram.svg')
         #end
         #set ($diagramURL = $diagram.getAttachmentURL($fileName, 'download', "v=$!diagram.version"))
         #set ($output = "{{html clean='false'}}&lt;img src='$diagramURL' alt='$escapetool.xml($diagramTitle)'/&gt;{{/html}}")

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
@@ -167,10 +167,17 @@
   #if ($services.security.authorization.hasAccess('view', $reference))
     #set ($diagram = $xwiki.getDocument($reference))
     #set ($diagramTitle = $diagram.plainTitle)
-    #if ($diagram.getObject('Diagram.DiagramClass'))
+    #set ($diagramObj = $diagram.getObject('Diagram.DiagramClass'))
+    #if ($diagramObj)
       #if ($xcontext.action == 'edit' || $xcontext.action == 'export' || $request.xpage == 'print'
           || $xcontext.macro.params.cached == 'true')
-        #set ($diagramURL = $diagram.getAttachmentURL('diagram.svg', 'download', "v=$!diagram.version"))
+        #set ($fileName = 'diagram.svg')
+        #set ($pngFileName = 'diagram.thumbnail.png')
+        #if ($xcontext.action == 'export' &amp;&amp; $diagramObj.getValue('exportUsingSVG') == 0
+            &amp;&amp; $diagram.getAttachment($pngFileName))
+          #set ($fileName = $pngFileName)
+        #end
+        #set ($diagramURL = $diagram.getAttachmentURL($fileName, 'download', "v=$!diagram.version"))
         #set ($output = "{{html clean='false'}}&lt;img src='$diagramURL' alt='$escapetool.xml($diagramTitle)'/&gt;{{/html}}")
       #else
         #set ($output = "{{display reference='$services.rendering.escape($reference, $xcontext.macro.doc.syntax)' /}}")

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramTemplate.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramTemplate.xml
@@ -54,6 +54,21 @@
       <defaultWeb/>
       <nameField/>
       <validationScript/>
+      <exportUsingSVG>
+        <customDisplay/>
+        <defaultValue>1</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <hint/>
+        <name>exportUsingSVG</name>
+        <number>1</number>
+        <prettyName>exportUsingSVG</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </exportUsingSVG>
     </class>
   </object>
 </xwikidoc>

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -40,7 +40,8 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity}}
-#if ($doc.getObject('Diagram.DiagramClass') || "$!request.source" != '')
+#set ($diagramObj = $doc.getObject('Diagram.DiagramClass'))
+#if ($diagramObj || "$!request.source" != '')
   #set ($discard = $xwiki.ssx.use('Diagram.DiagramSheet'))
   #set ($discard = $xwiki.jsx.use('Diagram.DiagramViewSheet'))
   #set ($toolbar = 'zoom layers pages lightbox')
@@ -60,7 +61,13 @@
   &gt;
     ## Show a preview of the diagram until the diagram viewer is loaded. This is also useful for export and WYSIWYG edit
     ## mode where the JavaScript code is not executed and thus the diagram viewer is never loaded.
-    #set ($diagramURL = $doc.getAttachmentURL('diagram.svg', 'download', "v=$!doc.version"))
+    #set ($fileName = 'diagram.svg')
+    #set ($pngFileName = 'diagram.thumbnail.png')
+    #if ($xcontext.action == 'export' &amp;&amp; $diagramObj.getValue('exportUsingSVG') == 0
+        &amp;&amp; $doc.getAttachment($pngFileName))
+      #set ($fileName = $pngFileName)
+    #end
+    #set ($diagramURL = $doc.getAttachmentURL($fileName, 'download', "v=$!doc.version"))
     &lt;img src="$diagramURL" alt="$escapetool.xml($doc.plainTitle)" /&gt;
   &lt;/div&gt;
   {{/html}}

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -61,11 +61,10 @@
   &gt;
     ## Show a preview of the diagram until the diagram viewer is loaded. This is also useful for export and WYSIWYG edit
     ## mode where the JavaScript code is not executed and thus the diagram viewer is never loaded.
-    #set ($fileName = 'diagram.svg')
-    #set ($pngFileName = 'diagram.thumbnail.png')
-    #if ($xcontext.action == 'export' &amp;&amp; $diagramObj.getValue('exportUsingSVG') == 0
-        &amp;&amp; $doc.getAttachment($pngFileName))
-      #set ($fileName = $pngFileName)
+    #set ($fileName = 'diagram.png')
+    #if ($xcontext.action != 'export' || $diagramObj.getValue('exportUsingSVG') == 1
+        || !$doc.getAttachment($fileName))
+      #set ($fileName = 'diagram.svg')
     #end
     #set ($diagramURL = $doc.getAttachmentURL($fileName, 'download', "v=$!doc.version"))
     &lt;img src="$diagramURL" alt="$escapetool.xml($doc.plainTitle)" /&gt;


### PR DESCRIPTION
… per diagram #102

* added exportUsingSVG class property so that the user can export the desired format, defaulting to svg
* upload png version of the diagram at save step