### PR TITLE
Add support for generating a higher resolution diagram image for PDF …

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramClass.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramClass.xml
@@ -65,26 +65,18 @@
       <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
     </exportUsingSVG>
     <pdfImageExportZoom>
-      <cache>0</cache>
       <customDisplay/>
       <disabled>0</disabled>
-      <displayType>select</displayType>
-      <hint>Specify the zoom applied to the PNG image used in PDF export. A bigger zoom will generate a bigger image with a better quality.</hint>
-      <multiSelect>0</multiSelect>
+      <hint>Specify the zoom (number &gt; 0) applied to the PNG image used in PDF export. A bigger zoom will generate a bigger image with a better quality, but with more time added for 'Save' action. A value larger than 5 might bring very little extra value.</hint>
       <name>pdfImageExportZoom</name>
       <number>2</number>
-      <picker>0</picker>
+      <numberType>integer</numberType>
       <prettyName>pdfImageExportZoom</prettyName>
-      <relationalStorage>0</relationalStorage>
-      <separator> </separator>
-      <separators>|, </separators>
-      <size>1</size>
-      <sort>none</sort>
+      <size>30</size>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <values>100%|200%|300%|400%</values>
-      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
     </pdfImageExportZoom>
   </class>
   <object>

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramClass.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramClass.xml
@@ -64,6 +64,28 @@
       <validationRegExp/>
       <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
     </exportUsingSVG>
+    <pdfImageExportZoom>
+      <cache>0</cache>
+      <customDisplay/>
+      <disabled>0</disabled>
+      <displayType>select</displayType>
+      <hint>Specify the zoom applied to the PNG image used in PDF export. A bigger zoom will generate a bigger image with a better quality.</hint>
+      <multiSelect>0</multiSelect>
+      <name>pdfImageExportZoom</name>
+      <number>2</number>
+      <picker>0</picker>
+      <prettyName>pdfImageExportZoom</prettyName>
+      <relationalStorage>0</relationalStorage>
+      <separator> </separator>
+      <separators>|, </separators>
+      <size>1</size>
+      <sort>none</sort>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <values>100%|200%|300%|400%</values>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+    </pdfImageExportZoom>
   </class>
   <object>
     <name>Diagram.DiagramClass</name>

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -170,8 +170,8 @@
       <code>/**
  * Adds support for editing diagrams stored in XWiki pages.
  */
-define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils', 'draw.io', 'xwiki-events-bridge'],
-    function($, xm, xutils, diagramUtils) {
+define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils', 'diagram-config', 'draw.io',
+    'xwiki-events-bridge'], function($, xm, xutils, diagramUtils, diagramConfig) {
   var files = [];
   window._xfiles = files;
   var createFile = function(ui, input, title, documentReference) {
@@ -245,26 +245,6 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
     left.done($.proxy(right, 'resolve')).fail($.proxy(right, 'reject'));
   };
 
-  var getScaleOfPNGImage = function() {
-    var scale = 1;
-    var doc = new XWiki.Document(xm.documentReference);
-    var spaces = doc.spaces.map(function(space) { return "spaces/" + space; });
-    var url = "/xwiki/rest/wikis/" + doc.wiki + "/" + spaces.join('/') + "/pages/" + doc.page
-        + "/objects/Diagram.DiagramClass/0/properties/pdfImageExportZoom";
-    $.ajax({
-      url: url,
-      async: false,
-    }).success(function(data) {
-      var scaleValues = {'100%': 1, '200%': 2, '300%': 3, '400%': 4};
-      // data holds the xml correspondent to pdfImageExportZoom property, with the percentage on the value child tag.
-      var domParser = new DOMParser();
-      var dom = domParser.parseFromString(data.children[0].outerHTML, "application/xml");
-      var valueElement = dom.getElementsByTagName('value')[0];
-      scale = scaleValues[valueElement.innerHTML];
-    });
-    return scale;
-  };
-
   var saveBlobAsImageAttachment = function(blob, fileName, documentReference) {
     var attachmentReference = new XWiki.AttachmentReference(fileName, documentReference);
     var uploadAttachment = $.proxy(xutils.uploadAttachment, null, blob, attachmentReference);
@@ -275,7 +255,6 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
   var imageCache = {};
   var saveFileAsPNGImageAttachment = function(file) {
     var deferred = $.Deferred();
-    var scale = getScaleOfPNGImage();
     file.getUi().exportToCanvas(/* callback */ function(canvas) {
       if (canvas) {
         canvas.toBlob(function(blob) {
@@ -288,7 +267,7 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
       new XWiki.widgets.Notification(
         $jsontool.serialize($services.localization.render('diagram.editor.saveAsImageAttachmentError')), 'error');
       deferred.reject();
-    }, /* limitHeight */ null, /* ignoreSelection */ true, /* scale */ scale);
+    }, /* limitHeight */ null, /* ignoreSelection */ true, /* scale */ diagramConfig.pdfImageExportZoom);
     return deferred.promise();
   };
 

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -245,6 +245,26 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
     left.done($.proxy(right, 'resolve')).fail($.proxy(right, 'reject'));
   };
 
+  var getScaleOfPNGImage = function() {
+    var scale = 1;
+    var doc = new XWiki.Document(xm.documentReference);
+    var spaces = doc.spaces.map(function(space) { return "spaces/" + space; });
+    var url = "/xwiki/rest/wikis/" + doc.wiki + "/" + spaces.join('/') + "/pages/" + doc.page
+        + "/objects/Diagram.DiagramClass/0/properties/pdfImageExportZoom";
+    $.ajax({
+      url: url,
+      async: false,
+    }).success(function(data) {
+      var scaleValues = {'100%': 1, '200%': 2, '300%': 3, '400%': 4};
+      // data holds the xml correspondent to pdfImageExportZoom property, with the percentage on the value child tag.
+      var domParser = new DOMParser();
+      var dom = domParser.parseFromString(data.children[0].outerHTML, "application/xml");
+      var valueElement = dom.getElementsByTagName('value')[0];
+      scale = scaleValues[valueElement.innerHTML];
+    });
+    return scale;
+  };
+
   var saveBlobAsImageAttachment = function(blob, fileName, documentReference) {
     var attachmentReference = new XWiki.AttachmentReference(fileName, documentReference);
     var uploadAttachment = $.proxy(xutils.uploadAttachment, null, blob, attachmentReference);
@@ -255,6 +275,7 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
   var imageCache = {};
   var saveFileAsPNGImageAttachment = function(file) {
     var deferred = $.Deferred();
+    var scale = getScaleOfPNGImage();
     file.getUi().exportToCanvas(/* callback */ function(canvas) {
       if (canvas) {
         canvas.toBlob(function(blob) {
@@ -267,7 +288,7 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
       new XWiki.widgets.Notification(
         $jsontool.serialize($services.localization.render('diagram.editor.saveAsImageAttachmentError')), 'error');
       deferred.reject();
-    }, /* limitHeight */ null, /* ignoreSelection */ true);
+    }, /* limitHeight */ null, /* ignoreSelection */ true, /* scale */ scale);
     return deferred.promise();
   };
 

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
@@ -40,14 +40,16 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity}}
-#if ($doc.getObject('Diagram.DiagramClass'))
+#set ($diagramObj = $doc.getObject('Diagram.DiagramClass'))
+#if ($diagramObj)
   #set ($diagramConfig = {
     "debug": $services.debug.minify.equals(false),
     "locale": $xcontext.locale,
     "mxGraphClientBasePath": $services.webjars.url('org.xwiki.contrib:mxgraph-client', ''),
     "mxGraphEditorBasePath": $services.webjars.url('org.xwiki.contrib:mxgraph-editor', ''),
     "drawIOBasePath": $services.webjars.url('org.xwiki.contrib:draw.io', ''),
-    "exportURL": $xwiki.getDocument('Diagram.DiagramConfig').getValue('exportURL')
+    "exportURL": $xwiki.getDocument('Diagram.DiagramConfig').getValue('exportURL'),
+    "pdfImageExportZoom": $diagramObj.getValue('pdfImageExportZoom')
   })
   #if ($xcontext.action == 'edit')
     {{include reference="Diagram.DiagramEditSheet" /}}

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramTemplate.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramTemplate.xml
@@ -69,6 +69,28 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
       </exportUsingSVG>
+      <pdfImageExportZoom>
+        <cache>0</cache>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <hint>Specify the zoom applied to the PNG image used in PDF export. A bigger zoom will generate a bigger image with a better quality.</hint>
+        <multiSelect>0</multiSelect>
+        <name>pdfImageExportZoom</name>
+        <number>2</number>
+        <picker>0</picker>
+        <prettyName>pdfImageExportZoom</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <sort>none</sort>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <values>100%|200%|300%|400%</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </pdfImageExportZoom>
     </class>
   </object>
 </xwikidoc>

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramTemplate.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramTemplate.xml
@@ -70,26 +70,18 @@
         <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
       </exportUsingSVG>
       <pdfImageExportZoom>
-        <cache>0</cache>
         <customDisplay/>
         <disabled>0</disabled>
-        <displayType>select</displayType>
-        <hint>Specify the zoom applied to the PNG image used in PDF export. A bigger zoom will generate a bigger image with a better quality.</hint>
-        <multiSelect>0</multiSelect>
+        <hint>Specify the zoom (number &gt; 0) applied to the PNG image used in PDF export. A bigger zoom will generate a bigger image with a better quality, but with more time added for 'Save' action. A value larger than 5 might bring very little extra value.</hint>
         <name>pdfImageExportZoom</name>
         <number>2</number>
-        <picker>0</picker>
+        <numberType>integer</numberType>
         <prettyName>pdfImageExportZoom</prettyName>
-        <relationalStorage>0</relationalStorage>
-        <separator> </separator>
-        <separators>|, </separators>
-        <size>1</size>
-        <sort>none</sort>
+        <size>30</size>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <values>100%|200%|300%|400%</values>
-        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+        <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
       </pdfImageExportZoom>
     </class>
   </object>


### PR DESCRIPTION
…export #103

* get the resolution selected by the user using rest api and use it as scale for draw.io exportToCanvas method