### PR TITLE
When renaming a diagram, the reference from the diagram macro is not …

### DIFF
--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/AbstractDiagramRunnable.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/AbstractDiagramRunnable.java
@@ -64,7 +64,7 @@ public abstract class AbstractDiagramRunnable extends AbstractXWikiRunnable
      * 
      * @return queueEntry the new diagram entry
      */
-    public DiagramQueueEntry processDiagram()
+    public DiagramQueueEntry getNextDiagramQueueEntry()
     {
         DiagramQueueEntry queueEntry;
 

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/AbstractDiagramRunnable.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/AbstractDiagramRunnable.java
@@ -1,0 +1,72 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.diagram.internal;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import com.xpn.xwiki.util.AbstractXWikiRunnable;
+
+/**
+ * Base class for diagram Runnable. It provides tools for working with diagramsQueue.
+ * 
+ * @version $Id$
+ * @since 1.14
+ */
+public abstract class AbstractDiagramRunnable extends AbstractXWikiRunnable
+{
+    /**
+     * Stop runnable entry.
+     */
+    public static final DiagramQueueEntry STOP_RUNNABLE_ENTRY = new DiagramQueueEntry(null, null);
+
+    /**
+     * Entries to be processed by this thread.
+     */
+    private BlockingQueue<DiagramQueueEntry> diagramsQueue;
+
+    /**
+     * Add entries to the thread's queue.
+     * 
+     * @param queueEntry the entry to be added
+     */
+    public void addToQueue(DiagramQueueEntry queueEntry)
+    {
+        this.diagramsQueue.add(queueEntry);
+    }
+
+    /**
+     * Create an empty blocking queue.
+     */
+    public void initilizeQueue()
+    {
+        this.diagramsQueue = new LinkedBlockingQueue<DiagramQueueEntry>();
+    }
+
+    /**
+     * Get the entries to be processed by the thread.
+     * 
+     * @return queue with the entries for the thread
+     */
+    public BlockingQueue<DiagramQueueEntry> getDiagramsQueue()
+    {
+        return this.diagramsQueue;
+    }
+}

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramLinksRunnable.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramLinksRunnable.java
@@ -21,7 +21,6 @@ package com.xwiki.diagram.internal;
 
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -33,18 +32,17 @@ import org.xwiki.model.reference.DocumentReference;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.doc.XWikiDocument;
-import com.xpn.xwiki.util.AbstractXWikiRunnable;
 import com.xwiki.diagram.internal.handlers.DiagramContentHandler;
 
 /**
- * Updates content and attachment of diagram for rename of backlinked pages.
+ * Updates content and attachment of a diagram after the rename of backlinked pages.
  * 
  * @version $Id$
  * @since 1.13
  */
-@Component(roles = DiagramRunnable.class)
+@Component(roles = DiagramLinksRunnable.class)
 @Singleton
-public class DiagramRunnable extends AbstractXWikiRunnable
+public class DiagramLinksRunnable extends AbstractDiagramRunnable
 {
     /**
      * Stop runnable entry.
@@ -61,12 +59,6 @@ public class DiagramRunnable extends AbstractXWikiRunnable
     private Provider<XWikiContext> contextProvider;
 
     /**
-     * Entries to be processed by this thread.
-     */
-    private BlockingQueue<DiagramQueueEntry> diagramsQueue;
-
-    /**
-     * {@inheritDoc}
      * 
      * @see com.xpn.xwiki.util.AbstractXWikiRunnable#runInternal()
      */
@@ -75,6 +67,8 @@ public class DiagramRunnable extends AbstractXWikiRunnable
     {
         while (!Thread.interrupted()) {
             DiagramQueueEntry queueEntry;
+            BlockingQueue<DiagramQueueEntry> diagramsQueue = this.getDiagramsQueue();
+
             try {
                 queueEntry = diagramsQueue.take();
             } catch (InterruptedException e) {
@@ -111,23 +105,5 @@ public class DiagramRunnable extends AbstractXWikiRunnable
                 logger.warn("Update diagram backlinks thread interrupted", e);
             }
         }
-    }
-
-    /**
-     * Add entries to the thread's queue.
-     * 
-     * @param queueEntry the entry to be added
-     */
-    public void addToQueue(DiagramQueueEntry queueEntry)
-    {
-        this.diagramsQueue.add(queueEntry);
-    }
-
-    /**
-     * Create an empty blocking queue.
-     */
-    public void initilizeQueue()
-    {
-        this.diagramsQueue = new LinkedBlockingQueue<DiagramQueueEntry>();
     }
 }

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramLinksRunnable.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramLinksRunnable.java
@@ -20,7 +20,6 @@
 package com.xwiki.diagram.internal;
 
 import java.util.List;
-import java.util.concurrent.BlockingQueue;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -66,18 +65,9 @@ public class DiagramLinksRunnable extends AbstractDiagramRunnable
     public void runInternal()
     {
         while (!Thread.interrupted()) {
-            DiagramQueueEntry queueEntry;
-            BlockingQueue<DiagramQueueEntry> diagramsQueue = this.getDiagramsQueue();
-
-            try {
-                queueEntry = diagramsQueue.take();
-            } catch (InterruptedException e) {
-                logger.warn("Diagrams update thread has been interrupted", e);
-                queueEntry = STOP_RUNNABLE_ENTRY;
-            }
+            DiagramQueueEntry queueEntry = processDiagram();
 
             if (queueEntry == STOP_RUNNABLE_ENTRY) {
-                diagramsQueue.clear();
                 break;
             }
 

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramLinksRunnable.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramLinksRunnable.java
@@ -65,7 +65,7 @@ public class DiagramLinksRunnable extends AbstractDiagramRunnable
     public void runInternal()
     {
         while (!Thread.interrupted()) {
-            DiagramQueueEntry queueEntry = processDiagram();
+            DiagramQueueEntry queueEntry = getNextDiagramQueueEntry();
 
             if (queueEntry == STOP_RUNNABLE_ENTRY) {
                 break;

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramMacroRunnable.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramMacroRunnable.java
@@ -68,7 +68,7 @@ public class DiagramMacroRunnable extends AbstractDiagramRunnable
     public void runInternal()
     {
         while (!Thread.interrupted()) {
-            DiagramQueueEntry queueEntry = processDiagram();
+            DiagramQueueEntry queueEntry = getNextDiagramQueueEntry();
 
             if (queueEntry == STOP_RUNNABLE_ENTRY) {
                 break;

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramMacroRunnable.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramMacroRunnable.java
@@ -1,0 +1,143 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.diagram.internal;
+
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.Block.Axes;
+import org.xwiki.rendering.block.XDOM;
+import org.xwiki.rendering.block.match.MacroBlockMatcher;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+
+/**
+ * Updates diagram macro reference parameter after the rename of a diagram.
+ * 
+ * @version $Id$
+ * @since 1.14
+ */
+@Component(roles = DiagramMacroRunnable.class)
+@Singleton
+public class DiagramMacroRunnable extends AbstractDiagramRunnable
+{
+    private static final String MACRO_REFERENCE_PARAMETER = "reference";
+    @Inject
+    private Provider<XWikiContext> contextProvider;
+
+    @Inject
+    @Named("compact")
+    private EntityReferenceSerializer<String> compactEntityReferenceSerializer;
+
+    @Inject
+    private Logger logger;
+
+    /**
+     * @see com.xpn.xwiki.util.AbstractXWikiRunnable#runInternal()
+     */
+    @Override
+    public void runInternal()
+    {
+        while (!Thread.interrupted()) {
+            DiagramQueueEntry queueEntry;
+            BlockingQueue<DiagramQueueEntry> diagramsQueue = this.getDiagramsQueue();
+
+            try {
+                queueEntry = diagramsQueue.take();
+            } catch (InterruptedException e) {
+                logger.warn("Diagrams update thread has been interrupted", e);
+                queueEntry = STOP_RUNNABLE_ENTRY;
+            }
+
+            if (queueEntry == STOP_RUNNABLE_ENTRY) {
+                diagramsQueue.clear();
+                break;
+            }
+
+            XWikiContext xcontext = contextProvider.get();
+            DocumentReference originalDocRef = queueEntry.originalDocRef;
+            DocumentReference currentDocRef = queueEntry.currentDocRef;
+
+            try {
+                // We need to take backlinks from the original document because at this step they are not loaded on
+                // the new document.
+                List<DocumentReference> backlinks =
+                    xcontext.getWiki().getDocument(originalDocRef, xcontext).getBackLinkedReferences(xcontext);
+
+                for (DocumentReference backlinkDocRef : backlinks) {
+                    XWikiDocument backlinkDoc = xcontext.getWiki().getDocument(backlinkDocRef, xcontext);
+
+                    updateDiagramMacrosReferences(backlinkDoc, currentDocRef, originalDocRef, xcontext);
+                }
+            } catch (XWikiException e) {
+                logger.debug(e.getFullMessage());
+            }
+        }
+    }
+
+    /**
+     * Update for a page diagram macros old references with new ones.
+     * 
+     * @param document document that need to be updated with the new reference
+     * @param newReference new diagram reference
+     * @param oldReference old diagram reference of a macro
+     * @param xcontext the XWikiContext
+     * @throws XWikiException if updating the document fails
+     */
+    public void updateDiagramMacrosReferences(XWikiDocument document, DocumentReference newReference,
+        DocumentReference oldReference, XWikiContext xcontext) throws XWikiException
+    {
+        XDOM backlinkDocXDOM = document.getXDOM();
+        List<Block> macroBlocks = backlinkDocXDOM.getBlocks(new MacroBlockMatcher("diagram"), Axes.CHILD);
+
+        String newReferenceString =
+            compactEntityReferenceSerializer.serialize(newReference, document.getDocumentReference());
+        String oldReferenceString =
+            compactEntityReferenceSerializer.serialize(oldReference, document.getDocumentReference());
+
+        Boolean modified = false;
+        for (Block macroBlock : macroBlocks) {
+            String macroReference = macroBlock.getParameter(MACRO_REFERENCE_PARAMETER);
+
+            if (!macroReference.equals(newReferenceString) && macroReference.equals(oldReferenceString)) {
+                macroBlock.setParameter(MACRO_REFERENCE_PARAMETER, newReferenceString);
+                modified = true;
+            }
+        }
+
+        if (modified) {
+            document.setContent(backlinkDocXDOM);
+            xcontext.getWiki().saveDocument(document, "Updated diagram macros references after diagram page rename",
+                xcontext);
+        }
+    }
+}

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/PageRenameListener.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/PageRenameListener.java
@@ -40,9 +40,11 @@ import org.xwiki.observation.ObservationContext;
 import org.xwiki.observation.event.Event;
 
 import com.xpn.xwiki.doc.XWikiDocument;
+import com.xwiki.diagram.internal.handlers.DiagramContentHandler;
 
 /**
- * Listens to rename of pages and starts a thread that will update backlinked diagrams.
+ * Listens to rename of pages and starts a thread that will update the content of backlinked diagrams. Also, for diagram
+ * pages it will start a thread for updating references of the diagram macro.
  * 
  * @version $Id$
  * @since 1.13
@@ -58,9 +60,14 @@ public class PageRenameListener extends AbstractEventListener implements Disposa
     protected static final String ROLE_HINT = "PageRenameEventListener";
 
     /**
-     * Thread that will handle updating diagram's content after a page rename.
+     * Thread that will handle updating diagram's content and attachment after a page rename.
      */
-    public Thread diagramThread;
+    public Thread diagramLinksThread;
+
+    /**
+     * Thread that will handle updating the reference of a diagram macro after a diagram rename.
+     */
+    public Thread diagramMacroThread;
 
     @Inject
     protected ObservationContext observationContext;
@@ -75,7 +82,10 @@ public class PageRenameListener extends AbstractEventListener implements Disposa
     private Logger logger;
 
     @Inject
-    private DiagramRunnable diagramRunnable;
+    private DiagramLinksRunnable diagramLinksRunnable;
+
+    @Inject
+    private DiagramMacroRunnable diagramMacroRunnable;
 
     /**
      * Constructor.
@@ -88,7 +98,12 @@ public class PageRenameListener extends AbstractEventListener implements Disposa
     @Override
     public void onEvent(Event event, Object source, Object data)
     {
-        startUpdateDiagramLinksThread();
+        if (this.diagramLinksThread == null) {
+            this.diagramLinksThread = startThread(this.diagramLinksRunnable, "Update Diagram Links Thread");
+        }
+        if (this.diagramMacroThread == null) {
+            this.diagramMacroThread = startThread(this.diagramMacroRunnable, "Update Diagram Macro Thread");
+        }
 
         if (observationContext.isIn(new JobStartedEvent("refactoring/rename"))) {
             Job job = jobContext.getCurrentJob();
@@ -102,36 +117,58 @@ public class PageRenameListener extends AbstractEventListener implements Disposa
                 DocumentReference currentDocRef = currentDoc.getDocumentReference();
 
                 if (destinationRef.equals(currentDocRef)) {
-                    this.diagramRunnable.addToQueue(new DiagramQueueEntry(originalDocRef, currentDocRef));
+                    startContentUpdating(currentDoc, new DiagramQueueEntry(originalDocRef, currentDocRef));
                 }
             }
         }
     }
 
     /**
-     * Actions for starting the thread.
+     * Add entries in the queue of threads that will update the content of pages after rename, in just two cases: update
+     * content of a diagram after renaming pages that are linked in the content, update reference parameter of diagram
+     * macro after renaming a diagram.
+     *
+     * @param currentDoc current document
+     * @param queueEntry entry to be added in the thread queue
      */
-    public void startUpdateDiagramLinksThread()
+    public void startContentUpdating(XWikiDocument currentDoc, DiagramQueueEntry queueEntry)
     {
-        if (this.diagramThread == null) {
-            this.diagramThread = new Thread(this.diagramRunnable);
-            this.diagramRunnable.initilizeQueue();
-            this.diagramThread.setName("Update Diagram Links Thread");
-            this.diagramThread.setDaemon(true);
-            this.diagramThread.start();
+        if (currentDoc.getXObject(DiagramContentHandler.DIAGRAM_CLASS) != null) {
+            this.diagramMacroRunnable.addToQueue(queueEntry);
         }
+        this.diagramLinksRunnable.addToQueue(queueEntry);
     }
 
     /**
-     * Actions for closing the thread.
+     * Actions for starting a thread.
+     *
+     * @param diagramRunnable runnable object that implements the run method
+     * @param threadName name of the thread
+     * @return thread that was started
+     */
+    public Thread startThread(AbstractDiagramRunnable diagramRunnable, String threadName)
+    {
+        Thread diagramThread = new Thread(diagramRunnable);
+        diagramRunnable.initilizeQueue();
+        diagramThread.setName(threadName);
+        diagramThread.setDaemon(true);
+        diagramThread.start();
+
+        return diagramThread;
+    }
+
+    /**
+     * Actions for closing a thread.
      * 
+     * @param diagramThread thread to be stopped
+     * @param diagramRunnable runnable object of the thread
      * @throws InterruptedException if any thread has interrupted the current thread
      */
-    public void stopUpdateDiagramLinksThread() throws InterruptedException
+    public void stopThread(Thread diagramThread, AbstractDiagramRunnable diagramRunnable) throws InterruptedException
     {
-        if (this.diagramThread != null) {
-            this.diagramRunnable.addToQueue(DiagramRunnable.STOP_RUNNABLE_ENTRY);
-            this.diagramThread.join();
+        if (diagramThread != null) {
+            diagramRunnable.addToQueue(AbstractDiagramRunnable.STOP_RUNNABLE_ENTRY);
+            diagramThread.join();
         }
     }
 
@@ -139,9 +176,10 @@ public class PageRenameListener extends AbstractEventListener implements Disposa
     public void dispose() throws ComponentLifecycleException
     {
         try {
-            stopUpdateDiagramLinksThread();
+            stopThread(this.diagramLinksThread, this.diagramLinksRunnable);
+            stopThread(this.diagramMacroThread, this.diagramMacroRunnable);
         } catch (InterruptedException e) {
-            logger.debug("Diagram update links thread interruped", e);
+            logger.debug("Diagram backlinks update thread interruped", e);
         }
     }
 }

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/PageRenameListener.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/PageRenameListener.java
@@ -149,7 +149,6 @@ public class PageRenameListener extends AbstractEventListener implements Disposa
     public Thread startThread(AbstractDiagramRunnable diagramRunnable, String threadName)
     {
         Thread diagramThread = new Thread(diagramRunnable);
-        diagramRunnable.initilizeQueue();
         diagramThread.setName(threadName);
         diagramThread.setDaemon(true);
         diagramThread.start();

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/DiagramContentHandler.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/DiagramContentHandler.java
@@ -94,7 +94,7 @@ public class DiagramContentHandler
         XWikiContext context = contextProvider.get();
 
         if (attachment != null) {
-            backlinkDoc.addAttachment(getUpdatedAttachment(attachment, oldDocRef, newDocRef));
+            backlinkDoc.setAttachment(getUpdatedAttachment(attachment, oldDocRef, newDocRef));
             context.getWiki().saveDocument(backlinkDoc, "Updated attachment after page rename", context);
         }
     }

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/StoreHandler.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/StoreHandler.java
@@ -1,0 +1,127 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.diagram.internal.handlers;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReferenceSerializer;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.doc.XWikiLink;
+import com.xpn.xwiki.store.XWikiHibernateBaseStore;
+import com.xpn.xwiki.store.XWikiHibernateBaseStore.HibernateCallback;
+import com.xpn.xwiki.store.XWikiStoreInterface;
+
+/**
+ * Handler for XWikiStore operations.
+ * 
+ * @version $Id$
+ * @since 1.13
+ */
+@Component(roles = StoreHandler.class)
+@Singleton
+public class StoreHandler
+{
+    @Inject
+    @Named("local")
+    private EntityReferenceSerializer<String> localEntityReferenceSerializer;
+
+    @Inject
+    @Named("compactwiki")
+    private EntityReferenceSerializer<String> compactwikiEntityReferenceSerializer;
+
+    @Inject
+    @Named("hibernate")
+    private Provider<XWikiStoreInterface> hibernateStoreProvider;
+
+    /**
+     * Get a document as XWikiLink.
+     * 
+     * @param document diagram document
+     * @param linkedDocRef reference of the linked document
+     * @return document casted to XWikiLink
+     */
+    public XWikiLink getXWikiLink(XWikiDocument document, DocumentReference linkedDocRef)
+    {
+        XWikiLink wikiLink = new XWikiLink();
+
+        wikiLink.setDocId(document.getId());
+        wikiLink.setFullName(localEntityReferenceSerializer.serialize(document.getDocumentReference()));
+        wikiLink.setLink(compactwikiEntityReferenceSerializer.serialize(linkedDocRef));
+
+        // Verify that the link reference isn't larger than 255 characters (and truncate it if
+        // that's the case) since otherwise that would lead to a DB error that would result in
+        // a fatal error, and the user would have a hard time understanding why his page failed
+        // to be saved.
+        wikiLink.setLink(StringUtils.substring(wikiLink.getLink(), 0, 255));
+
+        return wikiLink;
+    }
+
+    /**
+     * Delete backlinks from this document.
+     * 
+     * @param docId the id of the document
+     * @param context the current request context
+     * @throws XWikiException fail during delete action
+     */
+    public void deleteLinks(long docId, XWikiContext context) throws XWikiException
+    {
+        try {
+            getStore().executeWrite(context, new HibernateCallback<Object>()
+            {
+                @Override
+                public Object doInHibernate(Session session) throws XWikiException
+                {
+                    Query query = session.createQuery("delete from XWikiLink as link where link.id.docId = :docId");
+                    query.setParameter("docId", docId);
+                    query.executeUpdate();
+
+                    return Boolean.TRUE;
+                }
+            });
+        } catch (Exception e) {
+            throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,
+                XWikiException.ERROR_XWIKI_STORE_HIBERNATE_DELETING_LINKS, "Exception while deleting links", e);
+        }
+    }
+
+    /**
+     * Get instance of XWikiHibernateStore.
+     * 
+     * @return store system for execute store-specific actions.
+     * @throws ComponentLookupException if the store could not be reached
+     */
+    public XWikiHibernateBaseStore getStore() throws ComponentLookupException
+    {
+        return (XWikiHibernateBaseStore) hibernateStoreProvider.get();
+    }
+}

--- a/application-diagram-api/src/main/resources/META-INF/components.txt
+++ b/application-diagram-api/src/main/resources/META-INF/components.txt
@@ -3,7 +3,10 @@ com.xwiki.diagram.internal.DrawIOImagePathMigration
 com.xwiki.diagram.internal.StoreSVGAsAttachmentMigration
 com.xwiki.diagram.internal.PageRenameListener
 com.xwiki.diagram.internal.DiagramLinksListener
-com.xwiki.diagram.internal.DiagramRunnable
+com.xwiki.diagram.internal.DiagramLinksRunnable
+com.xwiki.diagram.internal.DiagramMacroRunnable
 com.xwiki.diagram.internal.handlers.GetDiagramLinksHandler
 com.xwiki.diagram.internal.handlers.DiagramContentHandler
 com.xwiki.diagram.internal.handlers.DiagramLinkHandler
+com.xwiki.diagram.internal.handlers.StoreHandler
+com.xwiki.diagram.internal.DiagramMacroListener


### PR DESCRIPTION
…updated with the new name #36

* added backlink from the diagram that was referenced inside the reference parameter and on diagram page rename update the reference from all the backlinked pages
* change deprecated method