### PR TITLE
The SVG isn't exported by default when doing a PDF export, although t…

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
@@ -171,10 +171,11 @@
     #if ($diagramObj)
       #if ($xcontext.action == 'edit' || $xcontext.action == 'export' || $request.xpage == 'print'
           || $xcontext.macro.params.cached == 'true')
-        #set ($fileName = 'diagram.png')
-        #if ($xcontext.action != 'export' || $diagramObj.getValue('exportUsingSVG') == 1
-            || !$diagram.getAttachment($fileName))
-          #set ($fileName = 'diagram.svg')
+        #set ($fileName = 'diagram.svg')
+        #set ($pngFileName = 'diagram.png')
+        #if ($xcontext.action == 'export' &amp;&amp; $diagramObj.getValue('exportUsingSVG') == 0
+            &amp;&amp; $diagram.getAttachment($pngFileName))
+          #set ($fileName = $pngFileName)
         #end
         #set ($diagramURL = $diagram.getAttachmentURL($fileName, 'download', "v=$!diagram.version"))
         #set ($output = "{{html clean='false'}}&lt;img src='$diagramURL' alt='$escapetool.xml($diagramTitle)'/&gt;{{/html}}")

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -61,10 +61,11 @@
   &gt;
     ## Show a preview of the diagram until the diagram viewer is loaded. This is also useful for export and WYSIWYG edit
     ## mode where the JavaScript code is not executed and thus the diagram viewer is never loaded.
-    #set ($fileName = 'diagram.png')
-    #if ($xcontext.action != 'export' || $diagramObj.getValue('exportUsingSVG') == 1
-        || !$doc.getAttachment($fileName))
-      #set ($fileName = 'diagram.svg')
+    #set ($fileName = 'diagram.svg')
+    #set ($pngFileName = 'diagram.png')
+    #if ($xcontext.action == 'export' &amp;&amp; $diagramObj.getValue('exportUsingSVG') == 0
+        &amp;&amp; $doc.getAttachment($pngFileName))
+      #set ($fileName = $pngFileName)
     #end
     #set ($diagramURL = $doc.getAttachmentURL($fileName, 'download', "v=$!doc.version"))
     &lt;img src="$diagramURL" alt="$escapetool.xml($doc.plainTitle)" /&gt;


### PR DESCRIPTION
…he property is in place #131

* use svg as default from code since we do not set exportUsingSVG at diagram creation step and  defaultValue has only the purpose of prefill before the first save (checking object mode after creating the diagram will leave the feeling that it was already set for svg)