### PR TITLE
No PNG or SVG is created while Saving a Diagram on IE 11 #135

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -257,9 +257,13 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
     var deferred = $.Deferred();
     file.getUi().exportToCanvas(/* callback */ function(canvas) {
       if (canvas) {
-        canvas.toBlob(function(blob) {
-          pipeDeferred(saveBlobAsImageAttachment(blob, 'diagram.png', file.documentReference), deferred);
-        });
+        try {
+          canvas.toBlob(function(blob) {
+            pipeDeferred(saveBlobAsImageAttachment(blob, 'diagram.png', file.documentReference), deferred);
+          });
+        } catch(err) {
+          deferred.reject();
+        }
       } else {
         deferred.reject();
       }


### PR DESCRIPTION
* toBlob is not working in out case for IE
* this issue is related to #59 and as is explained here the diagram cannot be saved as an image attachment in IE; this comment gives more details https://github.com/xwikisas/application-diagram/issues/59#issuecomment-532119659 