### PR TITLE
The content in the "Text" shape isn't showing in XWiki PDF export when there is text separated on different rows by Enter #118

### DIFF
--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/DiagramLinkHandler.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/DiagramLinkHandler.java
@@ -27,6 +27,7 @@ import javax.inject.Singleton;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -183,9 +184,11 @@ public class DiagramLinkHandler
         if (value == null || value.indexOf(DiagramLinkHandler.HREF) == -1) {
             return null;
         }
+        String linkElement = cleanLinkValue(value);
+
         try {
             // The value attribute contains an 'a' node that holds the link value.
-            String link = getLinkFromEmbeddedNode(value);
+            String link = getLinkFromEmbeddedNode(linkElement);
             if (link != null && isXWikiCustomLink(link)) {
                 return getResourceReferenceFromCustomLink(link);
             }
@@ -194,6 +197,19 @@ public class DiagramLinkHandler
         }
 
         return null;
+    }
+
+    /**
+     * If in a link cell there is also simple text, that will also be added in mxCell value, before or after the
+     * <a></a> tag. This needs to be cleaned, since just the link tag is needed.
+     *
+     * @param value value attribute of mxCell node
+     * @return just the link element inside
+     */
+    public String cleanLinkValue(String value)
+    {
+        String valueInsideLinkElement = StringUtils.substringBetween(value, "<a", "</a>");
+        return String.format("<a %s </a>", valueInsideLinkElement);
     }
 
     /**

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/DiagramLinkHandler.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/DiagramLinkHandler.java
@@ -19,22 +19,22 @@
  */
 package com.xwiki.diagram.internal.handlers;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.StringReader;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.xml.html.HTMLCleaner;
 
 /**
  * Handles links to wiki pages, contained by diagrams.
@@ -65,6 +65,9 @@ public class DiagramLinkHandler
      * The prefix added to the links inserted in a diagram.
      */
     private static final String CUSTOM_LINK_PREFIX = "data:xwiki/reference,";
+
+    @Inject
+    private HTMLCleaner defaultHTMLCleaner;
 
     @Inject
     private Logger logger;
@@ -184,11 +187,10 @@ public class DiagramLinkHandler
         if (value == null || value.indexOf(DiagramLinkHandler.HREF) == -1) {
             return null;
         }
-        String linkElement = cleanLinkValue(value);
 
         try {
             // The value attribute contains an 'a' node that holds the link value.
-            String link = getLinkFromEmbeddedNode(linkElement);
+            String link = getLinkFromEmbeddedNode(value);
             if (link != null && isXWikiCustomLink(link)) {
                 return getResourceReferenceFromCustomLink(link);
             }
@@ -197,19 +199,6 @@ public class DiagramLinkHandler
         }
 
         return null;
-    }
-
-    /**
-     * If in a link cell there is also simple text, that will also be added in mxCell value, before or after the
-     * <a></a> tag. This needs to be cleaned, since just the link tag is needed.
-     *
-     * @param value value attribute of mxCell node
-     * @return just the link element inside
-     */
-    public String cleanLinkValue(String value)
-    {
-        String valueInsideLinkElement = StringUtils.substringBetween(value, "<a", "</a>");
-        return String.format("<a %s </a>", valueInsideLinkElement);
     }
 
     /**
@@ -223,11 +212,10 @@ public class DiagramLinkHandler
      */
     private String getLinkFromEmbeddedNode(String value) throws SAXException, IOException, ParserConfigurationException
     {
-        // Create a DOM node with the value to take the href attribute from inside it.
-        Document doc =
-            DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new ByteArrayInputStream(value.getBytes()));
-        String link = ((Element) doc.getFirstChild()).getAttribute(HREF);
-
-        return link;
+        // Create a DOM using the value and take the href attribute from inside the a element.
+        // TODO: iterate though children nodes since there could be multiple links inside the given value.
+        Document doc = defaultHTMLCleaner.clean(new StringReader(value));
+        NodeList nodes = doc.getElementsByTagName("a");
+        return ((Element) nodes.item(0)).getAttribute(HREF);
     }
 }

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/DiagramLinkHandler.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/DiagramLinkHandler.java
@@ -30,7 +30,6 @@ import org.slf4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
@@ -215,7 +214,10 @@ public class DiagramLinkHandler
         // Create a DOM using the value and take the href attribute from inside the a element.
         // TODO: iterate though children nodes since there could be multiple links inside the given value.
         Document doc = defaultHTMLCleaner.clean(new StringReader(value));
-        NodeList nodes = doc.getElementsByTagName("a");
-        return ((Element) nodes.item(0)).getAttribute(HREF);
+        Element node = (Element) doc.getElementsByTagName("a").item(0);
+        if (node != null) {
+            return node.getAttribute(HREF);
+        }
+        return null;
     }
 }

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -597,7 +597,7 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
   };
 
   var isParagraphWithPartialStyle = function(node, nbOfSiblings) {
-    return node.nodeType === 3 || (isInlineElement(node) &amp;&amp; nbOfSiblings &gt; 1);
+    return node.nodeType === 3 || ((isInlineElement(node) || isBlockElement(node)) &amp;&amp; nbOfSiblings &gt; 1);
   };
 
   // For the current block of text take into consideration if those coordinates are already in use.
@@ -615,6 +615,19 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
     takenCoordinates.push(thisCoordinates);
     return h;
   };
+
+  var getAdjustedInitialCoordinates = function(w, h, fontSize) {
+    w = Math.round(w / 2);
+    // For smaller heights the result seems to corespond to the one in the original view, but for the others the font
+    // size is relevant.
+    // TODO: investigate the reasons behind this behavior.
+    if (h &lt; lineHeight) {
+      h = Math.round(h / 2);
+    } else {
+      h = Math.round(h / 2 - fontSize / 2);
+    }
+    return [w, h];
+  }
 
   // Create the basis of a svg element. Calculate new coordinates if is needed.
   var createSvgElement = function(s, w, h, tag, element, addAnchor) {
@@ -650,13 +663,13 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
 
   var convertTextElementToSvg = function(element, s, w, h, htmlConverter, str, rectWidth, isFirstChild) {
     if (element.tagName.toLowerCase() == 'br') {
-      return;
+      return document.createElementNS('http://www.w3.org/2000/svg', "text");
     }
     if (isFirstChild) {
       takenCoordinates = [];
     }
-    w = Math.round(w / 2);
-    h = Math.round((h + s.fontSize) / 2);
+    [w, h] = getAdjustedInitialCoordinates(w, h, s.fontSize);
+
     // Use 'tspan' for 'li' elements since they will be move inside a 'text' container along with a row delimiter.
     // Update h in case it was manually modified to take into consideration other inserted elements.
     var tag = isListItem(element) ? 'tspan' : 'text';
@@ -702,9 +715,84 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
     }
   };
 
+
+  /*
+   * Converts a partially styled element (e.g. link added to just a word of a phrase) to svg kepping as much as possible
+   * from the original element.
+   * When different types of elements are separated vertically (see Example 1), as long as each element is not a
+   * composite one, the result is mainly as the input. But, for cases when the styled element is inside a phrase (see
+   * Example 2), the result is a fallback to simple text.
+   * TODO: In the case of Example 3, when a child of a partially styled paragraph is itself a partially styled paragraph
+   * with "Text" nodes a fallback must be added. For now, elementsContainer.contents() separates the nodes that are
+   * connected and there isn't a smooth solution to get which elements were on the same line (maybe consider &lt;/br&gt;
+   * as divider). Even though it looks the same in html, Example 4 works compared to 3 since there are no text nodes,
+   * but this depends on how the user inserts the text.
+   *
+   * Example 1: &lt;div&gt; "Simple text" &lt;/br&gt; &lt;b&gt;Bolded text&lt;/b&gt; &lt;/div&gt;
+   * Example 2: &lt;div&gt; "Simple text" &lt;b&gt;Bolded text&lt;/b&gt; &lt;/div&gt;
+   * Example 3: &lt;div&gt; "Simple text" &lt;/br&gt; "Simple text" &lt;b&gt;Bolded text&lt;/b&gt; &lt;/div&gt;
+   * Example 4:
+   * &lt;div&gt;
+   * "Simple text" &lt;/br&gt;
+   * &lt;span&gt;"Simple text" &lt;b&gt;Bolded text&lt;/b&gt;&lt;/span&gt;
+   * &lt;/div&gt;
+  */
+  var convertPartiallyStyledParagraphToSVG = function(childNodes, s, w, h, htmlConverter, str, rectWidth) {
+    takenCoordinates = [];
+    [w, h] = getAdjustedInitialCoordinates(w, h, s.fontSize);
+
+    var container = createSvgElement(s, w, h, 'g', null, true);
+    // Resolve the basic case where the element is just a phrase with a styled element. Remove this after fixing
+    // the TODO described in the comment above.
+    var simpleNodes= childNodes.filter(function() {
+      return this.nodeType === 3 || isInlineElement(this);
+    });
+
+    if(simpleNodes.length == childNodes.length) {
+      var element = $('&lt;span&gt;&lt;/span&gt;').html(str)[0];
+      var alt = convertTextElementToSvg(element, s, w, h, htmlConverter, str, rectWidth, true);
+      return alt;
+    }
+
+    // Look only on first-level children since for now it is not supported to partially style paragraphs inside a
+    // partially styled paragraph.
+    childNodes.each(function(index) {
+      var element = $(this).clone()[0];
+      // Convert text content to element for consistency.
+      if (element.nodeType === 3) {
+        element = $('&lt;span&gt;&lt;/span&gt;').html(element.textContent)[0];
+      }
+
+      // Don't do anything for &lt;/br&gt; tags or empty elements.
+      if (element.tagName == 'br' || element.innerText == '') {
+        return;
+      }
+
+      // Modify the height if needed.
+      h = maybeChangeHeight(w, h, element);
+      var alt = createSvgElement(s, w, h, /* tag */ 'text', /* element */ element, /* addAnchor */ true);
+
+      // Set text content. Manually do text wrapping when the text is longer then the rectWidth by distributing it
+      // to tspan elements.
+      var textContent = element.innerText;
+      var contentWidth = getStrWidth(textContent, s);
+      if (contentWidth &gt; rectWidth) {
+        wrapText(alt, s, w, h, textContent, contentWidth, rectWidth);
+      } else {
+        alt.textContent = textContent;
+      }
+
+      alt = addTagSpecificStyle(element, s, w, h, htmlConverter, str, alt);
+      container.appendChild(alt)
+    });
+    return container;
+
+  };
+
   return {
     convertTextElementToSvg: convertTextElementToSvg,
-    isParagraphWithPartialStyle: isParagraphWithPartialStyle
+    isParagraphWithPartialStyle: isParagraphWithPartialStyle,
+    convertPartiallyStyledParagraphToSVG: convertPartiallyStyledParagraphToSVG
   };
 });
 /**
@@ -766,6 +854,7 @@ define('diagram-link-editor', [
           var s = this.state;
           var htmlConverter = document.createElement('textarea');
           var content = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+          var temporaryContent = document.createElementNS('http://www.w3.org/2000/svg', 'g');
           var elementsContainer = $(fo).children().first().children().first();
           var childNodes = elementsContainer.contents();
           // Take the width from parent rect, which is the last one found.
@@ -773,26 +862,31 @@ define('diagram-link-editor', [
           var rectWidth = rectangles[rectangles.length - 1].width.baseVal.valueAsString;
           try {
             if (childNodes.length &gt; 0) {
+              var isPartiallyStyledElement = false;
+              var alt;
               childNodes.each(function(index) {
                 // Make a clone of the node, to not alter the original child.
                 var node = $(this).clone()[0];
-                var stop = false;
-                // If this paragraph has partial styled nodes, like a link added to just a part of the text, fallback
-                // to display just the text, without any styles. This is done since is too complex to calculate the
+                // If this paragraph has partially styled nodes (i.e. link added to just a part of the text) create a
+                // fallback version of it, since not all the cases are supported and the created svg could not be
+                // compatible with the already created elements. This is done since is too complex to calculate the
                 // coordinates of the styled node, considering the last element added and that it may be needed to wrap
                 // the text.
                 if (svgHandler.isParagraphWithPartialStyle(node, childNodes.length)) {
-                  node = $('&lt;span&gt;&lt;/span&gt;').html(this.parentNode.innerText)[0];
-                  stop = true;
+                  alt = svgHandler.convertPartiallyStyledParagraphToSVG(childNodes, s, w, h, htmlConverter, str,
+                    rectWidth);
+                  isPartiallyStyledElement = true;
+                  return false;
+                } else {
+                  alt = svgHandler.convertTextElementToSvg(node, s, w, h, htmlConverter, str, rectWidth, index == 0);
+                  temporaryContent.appendChild(alt);
                 }
-                var alt = svgHandler.convertTextElementToSvg(node, s, w, h, htmlConverter, str, rectWidth, index == 0);
-                content.appendChild(alt);
-                // If we took the inner text of the parent, the other child nodes are not needed.
-                return !stop;
               });
+              content.appendChild(isPartiallyStyledElement ? alt : temporaryContent)
               return content;
             } else {
-              return originalCreateAlternateContent.call(this, fo, x, y, w, h, str, align, valign, wrap, format, overflow, clip, rotation);
+              return originalCreateAlternateContent.call(this, fo, x, y, w, h, str, align, valign, wrap, format,
+                overflow, clip, rotation);
             }
           } catch (e) {
             return originalCreateAlternateContent.apply(this, arguments);

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -717,16 +717,16 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
 
 
   /*
-   * Converts a partially styled element (e.g. link added to just a word of a phrase) to svg kepping as much as possible
-   * from the original element.
+   * Converts a partially styled element (e.g. link added to just a word of a phrase) to svg kepping as much as
+   * possible from the original element.
    * When different types of elements are separated vertically (see Example 1), as long as each element is not a
    * composite one, the result is mainly as the input. But, for cases when the styled element is inside a phrase (see
    * Example 2), the result is a fallback to simple text.
-   * TODO: In the case of Example 3, when a child of a partially styled paragraph is itself a partially styled paragraph
-   * with "Text" nodes a fallback must be added. For now, elementsContainer.contents() separates the nodes that are
-   * connected and there isn't a smooth solution to get which elements were on the same line (maybe consider &lt;/br&gt;
-   * as divider). Even though it looks the same in html, Example 4 works compared to 3 since there are no text nodes,
-   * but this depends on how the user inserts the text.
+   * TODO: In the case of Example 3, when a child of a partially styled paragraph is itself a partially styled
+   * paragraph with "Text" nodes a fallback must be added. For now, elementsContainer.contents() separates the nodes
+   * that are connected and there isn't a smooth solution to get which elements were on the same line (maybe consider
+   * &lt;/br&gt; as divider). Even though it looks the same in html, Example 4 works compared to 3 since there are
+   * no text nodes, but this depends on how the user inserts the text.
    *
    * Example 1: &lt;div&gt; "Simple text" &lt;/br&gt; &lt;b&gt;Bolded text&lt;/b&gt; &lt;/div&gt;
    * Example 2: &lt;div&gt; "Simple text" &lt;b&gt;Bolded text&lt;/b&gt; &lt;/div&gt;

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -626,7 +626,7 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
     } else {
       h = Math.round(h / 2 - fontSize / 2);
     }
-    return [w, h];
+    return {w, h};
   }
 
   // Create the basis of a svg element. Calculate new coordinates if is needed.
@@ -668,7 +668,9 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
     if (isFirstChild) {
       takenCoordinates = [];
     }
-    [w, h] = getAdjustedInitialCoordinates(w, h, s.fontSize);
+    var coordinates = getAdjustedInitialCoordinates(w, h, s.fontSize);
+    w = coordinates.w;
+    h = coordinates.h;
 
     // Use 'tspan' for 'li' elements since they will be move inside a 'text' container along with a row delimiter.
     // Update h in case it was manually modified to take into consideration other inserted elements.
@@ -739,7 +741,9 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
   */
   var convertPartiallyStyledParagraphToSVG = function(childNodes, s, w, h, htmlConverter, str, rectWidth) {
     takenCoordinates = [];
-    [w, h] = getAdjustedInitialCoordinates(w, h, s.fontSize);
+    var coordinates = getAdjustedInitialCoordinates(w, h, s.fontSize);
+    w = coordinates.w;
+    h = coordinates.h;
 
     var container = createSvgElement(s, w, h, 'g', null, true);
     // Resolve the basic case where the element is just a phrase with a styled element. Remove this after fixing


### PR DESCRIPTION
* treated separately the cases of partially styled elements and provide fallback to multiple such cases
* error was raised in java while parsing link+text nodes

Comparison on what the diagram shows:
![html](https://user-images.githubusercontent.com/22794181/81823757-4fa55380-953d-11ea-9303-c2ab2bd46272.png)

and what is on the XWiki PDF Export :
![after](https://user-images.githubusercontent.com/22794181/81823788-5d5ad900-953d-11ea-8a22-bf0529a80389.png)

