### PR TITLE
Diagram installation remains on hold on a XWiki Cloud instance #148

### DIFF
--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramLinksRunnable.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramLinksRunnable.java
@@ -43,11 +43,6 @@ import com.xwiki.diagram.internal.handlers.DiagramContentHandler;
 @Singleton
 public class DiagramLinksRunnable extends AbstractDiagramRunnable
 {
-    /**
-     * Stop runnable entry.
-     */
-    public static final DiagramQueueEntry STOP_RUNNABLE_ENTRY = new DiagramQueueEntry(null, null);
-
     @Inject
     private Logger logger;
 
@@ -58,7 +53,6 @@ public class DiagramLinksRunnable extends AbstractDiagramRunnable
     private Provider<XWikiContext> contextProvider;
 
     /**
-     * 
      * @see com.xpn.xwiki.util.AbstractXWikiRunnable#runInternal()
      */
     @Override

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/PageRenameListener.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/PageRenameListener.java
@@ -202,7 +202,7 @@ public class PageRenameListener extends AbstractEventListener implements Disposa
             stopThread(this.diagramLinksThread, this.diagramLinksRunnable);
             stopThread(this.diagramMacroThread, this.diagramMacroRunnable);
         } catch (InterruptedException e) {
-            logger.debug("Diagram backlinks update thread interruped", e);
+            logger.warn("Diagram backlinks update thread interruped", e);
         }
     }
 }


### PR DESCRIPTION
* static variable of abstract class was duplicated in child class
* changed logger method that was showing the message only on debug mode
* incorrect style on a page