### PR TITLE
Add support for disabling the features that require an external server #105

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramConfig.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramConfig.xml
@@ -54,6 +54,21 @@
       <defaultWeb/>
       <nameField/>
       <validationScript/>
+      <disableExternalServices>
+        <customDisplay/>
+        <defaultValue>0</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <hint/>
+        <name>disableExternalServices</name>
+        <number>2</number>
+        <prettyName>Disable External Services</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </disableExternalServices>
       <exportURL>
         <customDisplay/>
         <disabled>0</disabled>
@@ -68,6 +83,9 @@
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </exportURL>
     </class>
+    <property>
+      <disableExternalServices>0</disableExternalServices>
+    </property>
     <property>
       <exportURL>https://exp.draw.io/ImageExport4/export</exportURL>
     </property>

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramConfigClass.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramConfigClass.xml
@@ -49,6 +49,21 @@
     <defaultWeb/>
     <nameField/>
     <validationScript/>
+    <disableExternalServices>
+      <customDisplay/>
+      <defaultValue>0</defaultValue>
+      <disabled>0</disabled>
+      <displayFormType>select</displayFormType>
+      <displayType/>
+      <hint/>
+      <name>disableExternalServices</name>
+      <number>2</number>
+      <prettyName>Disable External Services</prettyName>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+    </disableExternalServices>
     <exportURL>
       <customDisplay/>
       <disabled>0</disabled>

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramConfigSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramConfigSheet.xml
@@ -43,6 +43,23 @@
 #macro (stripHTMLMacro $displayOutput)
   $stringtool.removeEnd($stringtool.removeStart($displayOutput, '{{html clean="false" wiki="false"}}'), '{{/html}}')
 #end
+#macro (showProperty $propertyName)
+  &lt;dl&gt;
+    &lt;dt&gt;
+      #set ($propertyClass = $xclass.get($propertyName))
+      &lt;label#if ($editing) for="${diagramConfigClassName}_0_${propertyName}"#end&gt;
+        $escapetool.xml($propertyClass.translatedPrettyName)
+      &lt;/label&gt;
+      #set ($hint = $propertyClass.hint)
+      #if ("$!hint" == '')
+        #set ($hint = $services.localization.render("${diagramConfigClassName}_${propertyName}_hint"))
+      #end
+      &lt;span class="xHint"&gt;$escapetool.xml($hint)&lt;/span&gt;
+    &lt;/dt&gt;
+    #set ($displayOutput = $doc.display($propertyName, $mode))
+    &lt;dd&gt;#stripHTMLMacro($displayOutput)&lt;/dd&gt;
+  &lt;/dl&gt;
+#end
 {{/velocity}}
 
 {{velocity}}
@@ -61,21 +78,8 @@
 #else
   &lt;div class="diagram-config xform"&gt;
 #end
-  &lt;dl&gt;
-    &lt;dt&gt;
-      #set ($propertyClass = $xclass.get('exportURL'))
-      &lt;label#if ($editing) for="${diagramConfigClassName}_0_exportURL"#end&gt;
-        $escapetool.xml($propertyClass.translatedPrettyName)
-      &lt;/label&gt;
-      #set ($hint = $propertyClass.hint)
-      #if ("$!hint" == '')
-        #set ($hint = $services.localization.render("${diagramConfigClassName}_exportURL_hint"))
-      #end
-      &lt;span class="xHint"&gt;$escapetool.xml($hint)&lt;/span&gt;
-    &lt;/dt&gt;
-    #set ($displayOutput = $doc.display('exportURL', $mode))
-    &lt;dd&gt;#stripHTMLMacro($displayOutput)&lt;/dd&gt;
-  &lt;/dl&gt;
+  #showProperty('exportURL')
+  #showProperty('disableExternalServices')
 #if ($xcontext.action == 'admin')
   &lt;p&gt;
     &lt;input type="submit" class="btn btn-primary" name="action_saveandcontinue"

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1052,6 +1052,44 @@ define('diagram-url-io', ['diagram-utils', 'draw.io'], function(diagramUtils) {
 });
 
 /**
+  * In case external services are disabled, stop the features that require it (export of pdf from diagram editor
+  * or png / jpeg export on IE) and show an info dialog.
+  */
+define('diagram-external-services', ['jquery', 'diagram-config', 'draw.io'], function($, diagramConfig) {
+  var showDisabledServicesDialog = function(editorUi) {
+    var errorMessage = $('&lt;div&gt;&lt;/div')
+      .html("$services.localization.render('diagram.editor.disabledExternalServices')");
+    errorMessage.addClass('externalServicesDialog');
+    var dlg = new CustomDialog(/*editorUi*/ editorUi, /*content*/ errorMessage[0], /*okFn*/ null, /*cancelFn*/ null,
+                               /*okButtonText*/ mxResources.get('ok'), /*helpLink*/ null, /*buttonsContent*/ null,
+                               /*hideCancel*/ true);
+    editorUi.showDialog(dlg.container, 250, 75, true, true);
+  }
+
+  // This is used from File -&gt; Export as.
+  var originalCreateDownloadRequest = EditorUi.prototype.createDownloadRequest;
+  EditorUi.prototype.createDownloadRequest = function(filename, format, ignoreSelection, base64, transparent,
+      currentPage, scale, border, grid, includeXml) {
+    if (diagramConfig.disableExternalServices) {
+      showDisabledServicesDialog(this);
+      return;
+    }
+    return originalCreateDownloadRequest.apply(this, arguments);
+  };
+
+  // This is used from File -&gt; Export as -&gt; Advanced...
+  var originalExportFile = ExportDialog.exportFile;
+  ExportDialog.exportFile = function(editorUi, name, format, bg, s, b, dpi) {
+    if (diagramConfig.disableExternalServices &amp;&amp; (format == 'pdf' ||
+        (['png', 'jpg', 'jpeg'].indexOf(format) != -1 &amp;&amp; !editorUi.isExportToCanvas()))) {
+      showDisabledServicesDialog(editorUi);
+      return;
+    }
+    return originalExportFile.apply(this, arguments);
+  }
+});
+
+/**
  * Integrates draw.io diagram editor in XWiki.
  */
 define('diagram-editor', [
@@ -1061,7 +1099,8 @@ define('diagram-editor', [
   'diagram-graph-xml-filter',
   'diagram-link-editor',
   'diagram-image-editor',
-  'diagram-url-io'
+  'diagram-url-io',
+  'diagram-external-services'
 ], function($, diagramStore, diagramUtils) {
 
   // These variables are used to decide if an image should be uploaded at original resolution or

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1058,13 +1058,14 @@ define('diagram-url-io', ['diagram-utils', 'draw.io'], function(diagramUtils) {
 define('diagram-external-services', ['jquery', 'diagram-config', 'draw.io'], function($, diagramConfig) {
   var showDisabledServicesDialog = function(editorUi) {
     var errorMessage = $('&lt;div&gt;&lt;/div')
-      .html("$services.localization.render('diagram.editor.disabledExternalServices')");
+      .html($jsontool.serialize($services.localization.render('diagram.editor.disabledExternalServices')));
+
     errorMessage.addClass('externalServicesDialog');
     var dlg = new CustomDialog(/*editorUi*/ editorUi, /*content*/ errorMessage[0], /*okFn*/ null, /*cancelFn*/ null,
                                /*okButtonText*/ mxResources.get('ok'), /*helpLink*/ null, /*buttonsContent*/ null,
                                /*hideCancel*/ true);
     editorUi.showDialog(dlg.container, 250, 75, true, true);
-  }
+  };
 
   // This is used from File -&gt; Export as.
   var originalCreateDownloadRequest = EditorUi.prototype.createDownloadRequest;
@@ -1086,7 +1087,7 @@ define('diagram-external-services', ['jquery', 'diagram-config', 'draw.io'], fun
       return;
     }
     return originalExportFile.apply(this, arguments);
-  }
+  };
 });
 
 /**

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
@@ -49,7 +49,8 @@
     "mxGraphEditorBasePath": $services.webjars.url('org.xwiki.contrib:mxgraph-editor', ''),
     "drawIOBasePath": $services.webjars.url('org.xwiki.contrib:draw.io', ''),
     "exportURL": $xwiki.getDocument('Diagram.DiagramConfig').getValue('exportURL'),
-    "pdfImageExportZoom": $diagramObj.getValue('pdfImageExportZoom')
+    "pdfImageExportZoom": $diagramObj.getValue('pdfImageExportZoom'),
+    "disableExternalServices": $xwiki.getDocument('Diagram.DiagramConfig').getValue('disableExternalServices')
   })
   #if ($xcontext.action == 'edit')
     {{include reference="Diagram.DiagramEditSheet" /}}
@@ -1022,6 +1023,13 @@ define('diagram-utils', ['jquery', 'diagram-link-handler'], function($, diagramL
 
 .diagram-container &gt; .thumbnail .box {
   margin-bottom: 0;
+}
+
+.externalServicesDialog {
+  text-align: center;
+  padding: 2%;
+  overflow: auto;
+  line-height: 1.3em;
 }</code>
     </property>
     <property>

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramTranslations.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramTranslations.xml
@@ -72,10 +72,13 @@ diagram.macro.viewNotAllowed=You are not allowed to view this diagram.
 
 # Diagram editor
 diagram.editor.saveAsImageAttachmentError=Error when saving the diagram as an image attachment.
+diagram.editor.disabledExternalServices=External services are disabled.
 
 # Diagram Configuration
 Diagram.DiagramConfigClass_exportURL=Export URL
-Diagram.DiagramConfigClass_exportURL_hint=The URL used to export the diagrams as image or PDF.</content>
+Diagram.DiagramConfigClass_exportURL_hint=The URL used to export the diagrams as image or PDF.
+Diagram.DiagramConfigClass_disableExternalServices=Disable External Services
+Diagram.DiagramConfigClass_disableExternalServices_hint=Disable features that require an external server</content>
   <object>
     <name>Diagram.DiagramTranslations</name>
     <number>0</number>


### PR DESCRIPTION
* add a property for disabling these features in DiagramConfig and based on this stop the export of pdf from diagram editor or png / jpeg export for IE
* consider that these export could be done from 2 places ( File -> Export As -> Advanced.. and File -> Export As)

External Services Dialog:
![exportServicesDisabledDialog](https://user-images.githubusercontent.com/22794181/84677112-f1520300-af36-11ea-878b-f238b8700f3a.png)
