### PR TITLE
Can't save diagrams with text inside certain shapes #144

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -873,9 +873,9 @@ define('diagram-link-editor', [
           // or any non squared shape, there is no rect and we fallback to the initial width of the text node, which is
           // less accurate.
           var containerWidth = this.state.initialWidth;
-          var rectangles = $(fo.parentNode.parentNode).find('rect');
-          if (rectangles) {
-            var containerWidth = rectangles[rectangles.length - 1].width.baseVal.valueAsString;
+          var prevNode = $(fo.parentNode).prev()[0];
+          if (prevNode.nodeName == 'rect') {
+            var containerWidth = prevNode.width.baseVal.valueAsString;
           }
           try {
             if (childNodes.length &gt; 0) {


### PR DESCRIPTION
* take into consideration only the previous element as a rect parent, otherwise any other rect will be considered as parent, leading to the blocked save if you do not have any rect in the diagram, or to a wrong width, which does not correspond to the current element.