### PR TITLE
Can't add links in IE 11 #137

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -518,7 +518,7 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
         var link = document.createElementNS('http://www.w3.org/2000/svg', 'a');
         link.setAttribute('x', w);
         link.setAttribute('y', h);
-        link.setAttribute('xlink:href', element.href);
+        link.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', element.href);
         // Add link decorations for the text.
         alt.setAttribute('fill', '#0000EE');
         alt.setAttribute('text-decoration', 'underline');

--- a/application-diagram-ui/src/main/resources/Diagram/ResourceSelector/WebHome.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/ResourceSelector/WebHome.xml
@@ -207,8 +207,10 @@
           selectedResource.reference = entry.value;
         }
       }
-      deferred.resolve(selectedResource);
-      modal.modal('hide');
+      // In IE the text needs to be visible before creating the link on it, so we wait for the modal to be closed.
+      modal.one('hidden.bs.modal', function() {
+        deferred.resolve(selectedResource);
+      }).modal('hide');
     });
     if (typeof settings.selectLabel === 'string') {
       selectButton.text(settings.selectLabel);


### PR DESCRIPTION
* wait for the modal to be closed before adding the link since in IE 'createLink' is not working if the text is not visible
* in IE we need to set xlink:href of the svg element with namespace