### PR TITLE
Adding multiple styles to a text element breaks the text display in XWiki PDF Export #153

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -494,17 +494,38 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
         // container, meaning also for ul and ol elements.
         alt.removeAttribute('text-anchor');
 
+        // Adapt elements for XWiki PDF export since links are not displayed when 'a' tag is placed inside a 'text'
+        // element.
+        var isLinkTag = alt.tagName.toLowerCase() == 'a';
+
         // Have a bullet for each row.
-        var delimiter = document.createElementNS('http://www.w3.org/2000/svg', 'tspan');
+        var delimiter = document.createElementNS('http://www.w3.org/2000/svg', isLinkTag ? 'text' : 'tspan');
         delimiter.textContent = "•";
         delimiter.setAttribute('x', w - 2 * spaceWidth);
+        delimiter.setAttribute('y', h);
 
         // Move all to a container.
-        var container = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        var container = document.createElementNS('http://www.w3.org/2000/svg', isLinkTag ? 'g' : 'text');
         container.setAttribute('x', w);
         container.setAttribute('y', h);
         container.appendChild(delimiter);
+
+        if (isLinkTag) {
+          // The text inside alt is distributed to 'tspan' elements and since they are showned only if are placed
+          // under a 'text' parent, we add it between them and the link.
+          var text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+          text.appendChild($(alt).children()[0]);
+          $(alt).html('');
+          alt.appendChild(text);
+        }
+
+        // If alt comes from a container, we should preserve the original parent.
+        var parent = alt.parentElement;
         container.appendChild(alt);
+        if (parent != null) {
+          parent.appendChild(container);
+          parent.removeAttribute('text-anchor');
+        }
         return container;
       case 'ul':
         // See comment from case 'li'.
@@ -514,6 +535,9 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
         // See comment from care 'li'.
         alt.removeAttribute('text-anchor');
         break;
+      case 'u':
+        alt.setAttribute('text-decoration', 'underline');
+        break;
       case 'a':
         var link = document.createElementNS('http://www.w3.org/2000/svg', 'a');
         link.setAttribute('x', w);
@@ -522,7 +546,13 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
         // Add link decorations for the text.
         alt.setAttribute('fill', '#0000EE');
         alt.setAttribute('text-decoration', 'underline');
+        alt.removeAttribute('text-anchor');
+        // If alt comes from a container, we should preserve the original parent.
+        var parent = alt.parentElement;
         link.appendChild(alt);
+        if (parent != null) {
+          parent.appendChild(link);
+        }
         return link;
       default:
         return alt;
@@ -571,6 +601,27 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
     });
   };
 
+  /*
+   * Consider containerWidth as the maximal width to do the word wrap when needed. Add the inner html only if the
+   * element is not a list, since the text should be distributed to children instead of being shown at once. The same
+   * is applied for when the text is longer then the containerWidth, since it will be distributed to tspan elements.
+   * Shorten the containerWidth send to text wrapper for 'li' elements since in their case an adittional space is
+   * added for the bullet delimiter and it shouldn't be included.
+  */
+  var addTextContent= function(element, htmlConverter, s, containerWidth, alt, w, h) {
+    htmlConverter.innerHTML = element.innerText;
+    var content = htmlConverter.value;
+    var contentWidth = getStrWidth(content, s);
+    if (!isListElement(element)) {
+      if (contentWidth &gt; containerWidth) {
+        containerWidth = isListItem(element) ? containerWidth - listBorder : containerWidth;
+        wrapText(alt, s, w, h, content, contentWidth, containerWidth);
+      } else {
+        alt.textContent = htmlConverter.value;
+      }
+    }
+  }
+
   var isHeadingElement = function(element) {
     var tag = element.tagName.toLowerCase();
     return ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].indexOf(tag) != -1;
@@ -599,6 +650,32 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
   var isParagraphWithPartialStyle = function(node, nbOfSiblings) {
     return node.nodeType === 3 || ((isInlineElement(node) || isBlockElement(node)) &amp;&amp; nbOfSiblings &gt; 1);
   };
+
+  var isStyleElement = function(element) {
+    if (element == null) { return false; }
+    return ['b', 'i', 'u', 'a'].indexOf(element.tagName.toLowerCase()) != -1 || isHeadingElement(element);
+  };
+
+  /*
+   * Get multiple styles of an element (i.e. b, i, u, a tags)
+  */
+  var getStylesFromElement = function(element) {
+    var styles = [];
+    // Partially styled elements are not supported, so consider only the styles of the main element.
+    var parentTextLength = element.parentElement.textContent.length;
+    if (element.textContent.length == parentTextLength) {
+      styles.push(element);
+    }
+    // Consider not just direct children.
+    var childElements = element.getElementsByTagName("*");
+    for (i = 0; i &lt; childElements.length; i++) {
+      var child = childElements[i];
+      if (child.textContent.length == parentTextLength) {
+        styles.push(child);
+      }
+    };
+    return styles;
+  }
 
   // For the current block of text take into consideration if those coordinates are already in use.
   // This is used when we are manually computing the container of children elements.
@@ -678,32 +755,26 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
     var alt = createSvgElement(s, w, h, tag, element, true);
     h = parseInt(alt.getAttribute('y'));
 
-    // Consider containerWidth as the maximal width to do the word wrap when needed. Add the inner html only if the
-    // element is not a list, since the text should be distributed to children instead of being shown at once. The same
-    // is applied for when the text is longer then the containerWidth, since it will be distributed to tspan elements.
-    // Shorten the containerWidth send to text wrapper for 'li' elements since in their case an adittional space is
-    // added for the bullet delimiter and it shouldn't be included.
-    htmlConverter.innerHTML = element.innerText;
-    var content = htmlConverter.value;
-    var contentWidth = getStrWidth(content, s);
-    if (!isListElement(element)) {
-      if (contentWidth &gt; containerWidth) {
-        containerWidth = isListItem(element) ? containerWidth - listBorder : containerWidth;
-        wrapText(alt, s, w, h, content, contentWidth, containerWidth);
-      } else {
-        alt.textContent = htmlConverter.value;
-      }
-    }
+    addTextContent(element, htmlConverter, s, containerWidth, alt, w, h);
 
-    // Convert recursively the children. Have a container that will hold the text element in case it has other children.
+    // Convert recursively the children. Have a container that will hold the elements in case there are other children.
+    // Consider the case when multiple styles are added to an element (e.g. &lt;i&gt;&lt;b&gt;txt&lt;/b&gt;&lt;/i&gt;).
+    // Traverse all children and keep the styles to just one element.
     if (element.childElements().length &gt; 0) {
       var container = createSvgElement(s, w, h, 'g', null, !isListElement(element));
       // TODO: Don't append alt element, unless it has a content.
       container.appendChild(alt);
       element.childElements().each(function(child) {
-        var childSvg = convertTextElementToSvg(child, s, w, h, htmlConverter, str, containerWidth, false);
-        if (childSvg != undefined) {
-          container.appendChild(childSvg);
+        if (isStyleElement(child)) {
+          var styles = getStylesFromElement(child);
+          styles.each(function(style) {
+            alt = addTagSpecificStyle(style, s, w, h, htmlConverter, str, alt, true);
+          });
+        } else {
+          var childSvg = convertTextElementToSvg(child, s, w, h, htmlConverter, str, containerWidth, false);
+          if (childSvg != undefined) {
+            container.appendChild(childSvg);
+          }
         }
       });
     }

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -496,7 +496,7 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
 
         // Adapt elements for XWiki PDF export since links are not displayed when 'a' tag is placed inside a 'text'
         // element.
-        var isLinkTag = alt.tagName.toLowerCase() == 'a';
+        var isLinkTag = alt.tagName.toLowerCase() === 'a';
 
         // Have a bullet for each row.
         var delimiter = document.createElementNS('http://www.w3.org/2000/svg', isLinkTag ? 'text' : 'tspan');
@@ -514,8 +514,11 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
           // The text inside alt is distributed to 'tspan' elements and since they are showned only if are placed
           // under a 'text' parent, we add it between them and the link.
           var text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+          // Copy only first child since it refers to the actual text content which, dependending on whether the
+          // text needed wrapping or not, is a 'tspan' with either just text inside or with multiple children
+          // representing the wrapped text.
           text.appendChild($(alt).children()[0]);
-          $(alt).html('');
+          $(alt).empty();
           alt.appendChild(text);
         }
 
@@ -547,10 +550,9 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
         // so we do it manually.
         if (alt.tagName.toLowerCase() == 'g') {
           var childNodes = $(alt).children();
-          childNodes.each(function(index) {
-            var child = childNodes[index];
-            child.setAttribute('fill', '#0000EE');
-            child.setAttribute('text-decoration', 'underline');
+          childNodes.each(function() {
+            this.setAttribute('fill', '#0000EE');
+            this.setAttribute('text-decoration', 'underline');
           });
         } else {
           alt.setAttribute('fill', '#0000EE');

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -543,9 +543,19 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
         link.setAttribute('x', w);
         link.setAttribute('y', h);
         link.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', element.href);
-        // Add link decorations for the text.
-        alt.setAttribute('fill', '#0000EE');
-        alt.setAttribute('text-decoration', 'underline');
+        // Add link decorations for the text. Some styles added to a 'g' are not distributed to it's children by FOP,
+        // so we do it manually.
+        if (alt.tagName.toLowerCase() == 'g') {
+          var childNodes = $(alt).children();
+          childNodes.each(function(index) {
+            var child = childNodes[index];
+            child.setAttribute('fill', '#0000EE');
+            child.setAttribute('text-decoration', 'underline');
+          });
+        } else {
+          alt.setAttribute('fill', '#0000EE');
+          alt.setAttribute('text-decoration', 'underline');
+        }
         alt.removeAttribute('text-anchor');
         // If alt comes from a container, we should preserve the original parent.
         var parent = alt.parentElement;
@@ -629,7 +639,7 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
 
   var isBlockElement = function(element) {
     var tag = element.tagName.toLowerCase();
-    return ['li', 'p', 'div'].indexOf(tag) != -1 || isHeadingElement(element);
+    return ['p', 'div'].indexOf(tag) != -1 || isHeadingElement(element);
   };
 
   var isListElement = function(element) {
@@ -647,9 +657,27 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
     return element &amp;&amp; element.tagName.toLowerCase() == 'li';
   };
 
-  var isParagraphWithPartialStyle = function(node, nbOfSiblings) {
+  var isNodeWithPartialStyle = function(node, nbOfSiblings) {
     return node.nodeType === 3 || ((isInlineElement(node) || isBlockElement(node)) &amp;&amp; nbOfSiblings &gt; 1);
   };
+
+  var isParagraphWithPartialStyle = function(node, nbOfSiblings) {
+    if (isNodeWithPartialStyle(node, nbOfSiblings)) {
+      return true;
+    }
+
+    // Consider also indirect children.
+    var childNodes = $(node).contents();
+    if ($(node).children().length &gt; 0) {
+      for (var i = 0; i &lt; childNodes.length; i++) {
+        var child = childNodes[i];
+        if (isParagraphWithPartialStyle(child, childNodes.length) == true) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 
   var isStyleElement = function(element) {
     if (element == null) { return false; }
@@ -666,14 +694,14 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
     if (element.textContent.length == parentTextLength) {
       styles.push(element);
     }
-    // Consider not just direct children.
+    // Consider also indirect children.
     var childElements = element.getElementsByTagName("*");
     for (i = 0; i &lt; childElements.length; i++) {
       var child = childElements[i];
       if (child.textContent.length == parentTextLength) {
         styles.push(child);
       }
-    };
+    }
     return styles;
   }
 
@@ -707,9 +735,9 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
   }
 
   // Create the basis of a svg element. Calculate new coordinates if is needed.
-  var createSvgElement = function(s, w, h, tag, element, addAnchor) {
+  var createSvgElement = function(s, w, h, tag, element, addAnchor, isPartiallyStyledElement) {
     var alt = document.createElementNS('http://www.w3.org/2000/svg', tag);
-    if (element &amp;&amp; isBlockElement(element)) {
+    if (element &amp;&amp; (isBlockElement(element) || isListItem(element) || isPartiallyStyledElement)) {
       h = maybeChangeHeight(w, h, element);
     }
     alt.setAttribute('x', w);
@@ -816,7 +844,19 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
     w = coordinates.w;
     h = coordinates.h;
 
-    var container = createSvgElement(s, w, h, 'g', null, true);
+    var container = createSvgElement(s, w, h, /* tag */ 'g', /* element */ null,
+        /* addAnchor */ !isListElement(childNodes[0]));
+    // Go to last level of child nodes in case there is a style added to the root element. Keep the styles to add
+    // them after assembling the element with its children.
+    var styles = [];
+    while (childNodes.length == 1 &amp;&amp; $(childNodes[0]).children().length &gt; 0) {
+      var rootNode = childNodes[0];
+      if (isStyleElement(rootNode)) {
+        styles.push(rootNode);
+      }
+      childNodes = $(rootNode).contents();
+    }
+
     // Resolve the basic case where the element is just a phrase with a styled element. Remove this after fixing
     // the TODO described in the comment above.
     var simpleNodes= childNodes.filter(function() {
@@ -843,22 +883,21 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
         return;
       }
 
-      // Modify the height if needed.
-      h = maybeChangeHeight(w, h, element);
-      var alt = createSvgElement(s, w, h, /* tag */ 'text', /* element */ element, /* addAnchor */ true);
+      // Consider that list elements will be moved to a 'text' container and in this case 'tspan' should be used as
+      // child tag. Specify that it is a partially styled element because in this case it could contain '&lt;br&gt;'
+      // tags and the children would need to have changed coordinates (heights) when they are created.
+      var alt = createSvgElement(s, w, h, /* tag */ isListItem(element) ? 'tspan' : 'text', /* element */ element,
+          /* addAnchor */ true, /* isPartiallyStyledElement */ true);
+      h = parseInt(alt.getAttribute('y'));
 
-      // Set text content. Manually do text wrapping when the text is longer then the containerWidth by distributing it
-      // to tspan elements.
-      var textContent = element.innerText;
-      var contentWidth = getStrWidth(textContent, s);
-      if (contentWidth &gt; containerWidth) {
-        wrapText(alt, s, w, h, textContent, contentWidth, containerWidth);
-      } else {
-        alt.textContent = textContent;
-      }
+      addTextContent(element, htmlConverter, s, containerWidth, alt, w, h);
 
       alt = addTagSpecificStyle(element, s, w, h, htmlConverter, str, alt);
-      container.appendChild(alt)
+      container.appendChild(alt);
+    });
+    // Consider the case when multiple styles are added to the root element.
+    styles.each(function(style) {
+      container = addTagSpecificStyle(style, s, w, h, htmlConverter, str, container, true);
     });
     return container;
 

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -630,7 +630,7 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
         alt.textContent = htmlConverter.value;
       }
     }
-  }
+  };
 
   var isHeadingElement = function(element) {
     var tag = element.tagName.toLowerCase();
@@ -677,7 +677,7 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
       }
     }
     return false;
-  }
+  };
 
   var isStyleElement = function(element) {
     if (element == null) { return false; }
@@ -703,7 +703,7 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
       }
     }
     return styles;
-  }
+  };
 
   // For the current block of text take into consideration if those coordinates are already in use.
   // This is used when we are manually computing the container of children elements.


### PR DESCRIPTION
* when multiple styles are added to an element, traverse all children and keep the styles to just one element
* change for partially styled elements also, since this case is treated differently
* identify partially styled elements even if they are not first level children; use these elements when converting them to svg instead of the root element and add needed styles at the end
* treat 'a' and 'li' cases differently since for them a container is returned instead of the given alt
* move functionality to method since it is used in 2 places;

Editor:
![153_editor](https://user-images.githubusercontent.com/22794181/87389261-1a55ca00-c5af-11ea-9158-c5695d364599.png)

PDF Export:
![153_pdf](https://user-images.githubusercontent.com/22794181/87389259-19bd3380-c5af-11ea-9048-e14e4167c534.png)

