### PR TITLE
Update draw.io to the latest version

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1065,7 +1065,7 @@ define('diagram-image-editor', ['xwiki-utils', 'diagram-link-handler', 'draw.io'
   // Override for uploading the image as attachment instead of encode it to Base64.
   var originalImportFiles = EditorUi.prototype.importFiles;
   EditorUi.prototype.importFiles = function(files, x, y, maxSize, fn, resultFn, filterFn, barrierFn, resizeDialog,
-      maxBytes, resampleThreshold, ignoreEmbeddedXml) {
+      maxBytes, resampleThreshold, ignoreEmbeddedXml, evt) {
     let importFilesArgs = arguments;
     if (fn) {
       let editorUi = this;
@@ -1149,16 +1149,13 @@ define('diagram-url-io', ['diagram-utils', 'draw.io'], function(diagramUtils) {
   };
 
   // Custom diagram import from URL.
-  var originalLoadUrl = EditorUi.prototype.loadUrl;
-  EditorUi.prototype.loadUrl = function(url, success, error, forceBinary, retry, dataUriPrefix) {
+  var loadUrl = function(url) {
+    var diagramXML = null;
     let exportedUrl = getParameterValueFromURL('url', url);
     if (exportedUrl) {
-      let diagramXML = diagramUtils.getDiagramXMLFromURL(exportedUrl);
-      if (diagramXML) {
-        return success(diagramXML);
-      }
+      diagramXML = diagramUtils.getDiagramXMLFromURL(exportedUrl);
     }
-    return originalLoadUrl.apply(this, arguments);
+    return diagramXML;
   };
 
   // Custom diagram export as URL (using the current host).
@@ -1181,6 +1178,10 @@ define('diagram-url-io', ['diagram-utils', 'draw.io'], function(diagramUtils) {
     }
     return rawURL;
   }
+
+  return {
+    loadUrl: loadUrl
+  };
 });
 
 /**
@@ -1229,12 +1230,12 @@ define('diagram-editor', [
   'jquery',
   'diagram-store',
   'diagram-utils',
+  'diagram-url-io',
   'diagram-graph-xml-filter',
   'diagram-link-editor',
   'diagram-image-editor',
-  'diagram-url-io',
   'diagram-external-services'
-], function($, diagramStore, diagramUtils) {
+], function($, diagramStore, diagramUtils, diagramUrlIO) {
 
   // These variables are used to decide if an image should be uploaded at original resolution or
   // should be declined for being too big.
@@ -1257,6 +1258,7 @@ define('diagram-editor', [
     $(editorUI.container).data('diagramEditor', editorUI).trigger('diagramEditorCreated', editorUI);
     // Fix the editor UI before loading the diagram because layout changes can influence the way the shapes are drawn.
     fixEditorUI(editorUI);
+    fixLoadUrl(editorUI);
     var file = diagramStore.createFile(editorUI, options.input, options.fileName, options.documentReference);
     // The first letter of the file name is used to determine the storage type. Let's use 'X' for XWiki storage.
     editorUI.loadFile('X' + options.fileName, true, file);
@@ -1270,6 +1272,18 @@ define('diagram-editor', [
     removeCompactModeToggle(editorUI);
     fixFullScreenToggle(editorUI);
     fixEditorButtons($(editorUI.container));
+  };
+
+  var fixLoadUrl = function(editorUI) {
+    // Custom diagram import from URL.
+    var originalLoadUrl = editorUI.editor.loadUrl;
+    editorUI.editor.loadUrl = function(url, success, error, forceBinary, retry, dataUriPrefix, noBinary, headers) {
+      var diagramXML = diagramUrlIO.loadUrl(url);
+      if (diagramXML != null) {
+        return success(diagramXML);
+      }
+      return originalLoadUrl.apply(this, arguments);
+    };
   };
 
   //

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -912,10 +912,10 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
 
   };
 
-  // Fix x and y coordinates, which are used when foreignObject is not supported and the view fallbacks to svg.
-  // This code is taken from an older draw.io version, since starting with 12.5.0 the transform attribute doesn't take
-  // into consideration the coordinates, but only the foOffset.
-  var adjustAlternateTextCoordinates = function(fo, x, y , w , h, s, align, valign, overflow, rotation, foOffset) {
+  // Fix the transform attribute of the element that is used when foreignObjects are not supported and the view
+  // fallbacks to svg. This code is taken from an older draw.io version, since starting with 12.5.0 the transform
+  // attribute doesn't take into consideration the coordinates, but only the foOffset.
+  var adjustAlternateTextCoordinates = function(group, x, y , w , h, s, align, valign, overflow, rotation, foOffset) {
         x += s.dx;
         y += s.dy;
         var dx = 0;
@@ -956,9 +956,7 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
         }
 
         var transform = 'translate(' + (Math.round(x) + foOffset) + ',' + (Math.round(y) + foOffset) + ')' + tr;
-        fo.parentElement.setAttribute('transform', transform);
-
-        return [x, y];
+        group.setAttribute('transform', transform);
   };
 
   return {
@@ -1051,9 +1049,6 @@ define('diagram-link-editor', [
           if (prevNode &amp;&amp; prevNode.nodeName == 'rect') {
             var containerWidth = prevNode.width.baseVal.valueAsString;
           }
-          var coordinates = svgHandler.adjustAlternateTextCoordinates(fo, x, y , w , h, s, align, valign, overflow, rotation, this.foOffset);
-          x = coordinates[0];
-          y = coordinates[1];
           try {
             if (childNodes.length &gt; 0) {
               var isPartiallyStyledElement = false;
@@ -1077,6 +1072,8 @@ define('diagram-link-editor', [
                 }
               });
               content.appendChild(isPartiallyStyledElement ? alt : temporaryContent)
+              svgHandler.adjustAlternateTextCoordinates(content, x, y, w, h, s, align, valign, overflow, rotation,
+                this.foOffset);
               return content;
             } else {
               return originalCreateAlternateContent.call(this, fo, x, y, w, h, str, align, valign, wrap, format,

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1266,7 +1266,6 @@ define('diagram-editor', [
   };
 
   var fixEditorUI = function(editorUI) {
-    hideFooter(editorUI);
     cleanMenu(editorUI);
     fixKeyboardShortcutsAction(editorUI);
     removeCompactModeToggle(editorUI);
@@ -1323,16 +1322,6 @@ define('diagram-editor', [
       return null;
     }
     return originalAddItem.apply(this, arguments);
-  };
-
-  //
-  // Hide the editor footer.
-  //
-  var hideFooter = function(editorUI) {
-    // We call this just in case the footer is visible.
-    editorUI.hideFooter();
-    // Make sure the diagram editor doesn't leave space for the footer.
-    editorUI.footerHeight = 0;
   };
 
   //
@@ -1401,7 +1390,7 @@ define('diagram-editor', [
   //
   var removeCompactModeToggle = function(editorUI) {
     if (typeof editorUI.toggleCompactMode === 'function') {
-      editorUI.toggleCompactMode(true);
+      editorUI.toggleCompactMode(/* visible: */ false);
       var buttons = $(editorUI.container).find('.geToolbarContainer &gt; a.geButton');
       buttons.last().remove();
       buttons.css('right', function(index, value) {

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1248,8 +1248,8 @@ define('diagram-editor', [
   //
   var createDiagramEditor = function(options) {
     options = options || {};
-    // Todo: this is needed since we do not use drafts and it would create the file to soon, leading to the file being
-    // opened in a new window.
+    // This is needed since we do not use drafts and it would create the file to soon, leading to the file being opened
+    // in a new window.
     EditorUi.enableDrafts = false;
     var editor = new Editor(/* chromeless: */ uiTheme === 'min', options.themes, /* model: */ null, /* graph: */ null,
       /* editable: */ true);

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -912,10 +912,60 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
 
   };
 
+  // Fix x and y coordinates, which are used when foreignObject is not supported and the view fallbacks to svg.
+  // This code is taken from an older draw.io version, since starting with 12.5.0 the transform attribute doesn't take
+  // into consideration the coordinates, but only the foOffset.
+  var adjustAlternateTextCoordinates = function(fo, x, y , w , h, s, align, valign, overflow, rotation, foOffset) {
+        x += s.dx;
+        y += s.dy;
+        var dx = 0;
+        var dy = 0;
+
+        if (align == mxConstants.ALIGN_CENTER) {
+          dx -= w / 2;
+        } else if (align == mxConstants.ALIGN_RIGHT) {
+          dx -= w;
+        }
+        x += dx;
+
+        if (valign == mxConstants.ALIGN_MIDDLE) {
+          dy -= h / 2;
+        } else if (valign == mxConstants.ALIGN_BOTTOM) {
+          dy -= h;
+        }
+
+        if (overflow != 'fill' &amp;&amp; mxClient.IS_FF &amp;&amp; mxClient.IS_WIN) {
+          dy -= 2;
+        }
+        y += dy;
+
+        var tr = (s.scale != 1) ? 'scale(' + s.scale + ')' : '';
+
+        if (s.rotation != 0 &amp;&amp; this.rotateHtml) {
+          tr += 'rotate(' + (s.rotation) + ',' + (w / 2) + ',' + (h / 2) + ')';
+          var pt = this.rotatePoint((x + w / 2) * s.scale, (y + h / 2) * s.scale, s.rotation, s.rotationCx, s.rotationCy);
+          x = pt.x - w * s.scale / 2;
+          y = pt.y - h * s.scale / 2;
+        } else {
+          x *= s.scale;
+          y *= s.scale;
+        }
+
+        if (rotation != 0) {
+          tr += 'rotate(' + (rotation) + ',' + (-dx) + ',' + (-dy) + ')';
+        }
+
+        var transform = 'translate(' + (Math.round(x) + foOffset) + ',' + (Math.round(y) + foOffset) + ')' + tr;
+        fo.parentElement.setAttribute('transform', transform);
+
+        return [x, y];
+  };
+
   return {
     convertTextElementToSvg: convertTextElementToSvg,
     isParagraphWithPartialStyle: isParagraphWithPartialStyle,
-    convertPartiallyStyledParagraphToSVG: convertPartiallyStyledParagraphToSVG
+    convertPartiallyStyledParagraphToSVG: convertPartiallyStyledParagraphToSVG,
+    adjustAlternateTextCoordinates: adjustAlternateTextCoordinates
   };
 });
 /**
@@ -947,11 +997,16 @@ define('diagram-link-editor', [
     return originalText.apply(this, arguments);
   };
 
+  // Don't add warning when the viewer doesn't supports SVG 1.1, since we create a fallback for foreignObjects.
+  Graph.prototype.addForeignObjectWarning = function(canvas, root) {
+    // Do nothing.
+  }
+
   // Overwrite Graph.getSvg in order to replace XWiki custom links with absolute URLs.
   // Also fix the text fallback for viewers with no support for foreignObjects.
   var originalGraphGetSVG = Graph.prototype.getSvg;
   Graph.prototype.getSvg = function(background, scale, border, nocrop, crisp, ignoreSelection, showText, imgExport,
-      linkTarget, hasShadow) {
+      linkTarget, hasShadow, incExtFonts, keepTheme, exportType, cells) {
     imgExport = imgExport || this.createSvgImageExport();
     var originalGetLinkForCellState = imgExport.getLinkForCellState;
     imgExport.getLinkForCellState = function() {
@@ -996,6 +1051,9 @@ define('diagram-link-editor', [
           if (prevNode &amp;&amp; prevNode.nodeName == 'rect') {
             var containerWidth = prevNode.width.baseVal.valueAsString;
           }
+          var coordinates = svgHandler.adjustAlternateTextCoordinates(fo, x, y , w , h, s, align, valign, overflow, rotation, this.foOffset);
+          x = coordinates[0];
+          y = coordinates[1];
           try {
             if (childNodes.length &gt; 0) {
               var isPartiallyStyledElement = false;
@@ -1035,7 +1093,7 @@ define('diagram-link-editor', [
     };
     try {
       return originalGraphGetSVG.call(this, background, scale, border, nocrop, crisp, ignoreSelection, showText,
-        imgExport, linkTarget, hasShadow);
+        imgExport, linkTarget, hasShadow, incExtFonts, keepTheme, exportType, cells);
     } finally {
       imgExport.getLinkForCellState = originalGetLinkForCellState;
       imgExport.drawState = originalDrawState;

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -916,47 +916,47 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
   // fallbacks to svg. This code is taken from an older draw.io version, since starting with 12.5.0 the transform
   // attribute doesn't take into consideration the coordinates, but only the foOffset.
   var adjustAlternateTextCoordinates = function(group, x, y , w , h, s, align, valign, overflow, rotation, foOffset) {
-        x += s.dx;
-        y += s.dy;
-        var dx = 0;
-        var dy = 0;
+    x += s.dx;
+    y += s.dy;
+    var dx = 0;
+    var dy = 0;
 
-        if (align == mxConstants.ALIGN_CENTER) {
-          dx -= w / 2;
-        } else if (align == mxConstants.ALIGN_RIGHT) {
-          dx -= w;
-        }
-        x += dx;
+    if (align == mxConstants.ALIGN_CENTER) {
+      dx -= w / 2;
+    } else if (align == mxConstants.ALIGN_RIGHT) {
+      dx -= w;
+    }
+    x += dx;
 
-        if (valign == mxConstants.ALIGN_MIDDLE) {
-          dy -= h / 2;
-        } else if (valign == mxConstants.ALIGN_BOTTOM) {
-          dy -= h;
-        }
+    if (valign == mxConstants.ALIGN_MIDDLE) {
+      dy -= h / 2;
+    } else if (valign == mxConstants.ALIGN_BOTTOM) {
+      dy -= h;
+    }
 
-        if (overflow != 'fill' &amp;&amp; mxClient.IS_FF &amp;&amp; mxClient.IS_WIN) {
-          dy -= 2;
-        }
-        y += dy;
+    if (overflow != 'fill' &amp;&amp; mxClient.IS_FF &amp;&amp; mxClient.IS_WIN) {
+      dy -= 2;
+    }
+    y += dy;
 
-        var tr = (s.scale != 1) ? 'scale(' + s.scale + ')' : '';
+    var tr = (s.scale != 1) ? 'scale(' + s.scale + ')' : '';
 
-        if (s.rotation != 0 &amp;&amp; this.rotateHtml) {
-          tr += 'rotate(' + (s.rotation) + ',' + (w / 2) + ',' + (h / 2) + ')';
-          var pt = this.rotatePoint((x + w / 2) * s.scale, (y + h / 2) * s.scale, s.rotation, s.rotationCx, s.rotationCy);
-          x = pt.x - w * s.scale / 2;
-          y = pt.y - h * s.scale / 2;
-        } else {
-          x *= s.scale;
-          y *= s.scale;
-        }
+    if (s.rotation != 0 &amp;&amp; this.rotateHtml) {
+      tr += 'rotate(' + (s.rotation) + ',' + (w / 2) + ',' + (h / 2) + ')';
+      var pt = this.rotatePoint((x + w / 2) * s.scale, (y + h / 2) * s.scale, s.rotation, s.rotationCx, s.rotationCy);
+      x = pt.x - w * s.scale / 2;
+      y = pt.y - h * s.scale / 2;
+    } else {
+      x *= s.scale;
+      y *= s.scale;
+    }
 
-        if (rotation != 0) {
-          tr += 'rotate(' + (rotation) + ',' + (-dx) + ',' + (-dy) + ')';
-        }
+    if (rotation != 0) {
+      tr += 'rotate(' + (rotation) + ',' + (-dx) + ',' + (-dy) + ')';
+    }
 
-        var transform = 'translate(' + (Math.round(x) + foOffset) + ',' + (Math.round(y) + foOffset) + ')' + tr;
-        group.setAttribute('transform', transform);
+    var transform = 'translate(' + (Math.round(x) + foOffset) + ',' + (Math.round(y) + foOffset) + ')' + tr;
+    group.setAttribute('transform', transform);
   };
 
   return {
@@ -995,7 +995,7 @@ define('diagram-link-editor', [
     return originalText.apply(this, arguments);
   };
 
-  // Don't add warning when the viewer doesn't supports SVG 1.1, since we create a fallback for foreignObjects.
+  // Don't add warning when the viewer doesn't support SVG 1.1, since we create a fallback for foreignObjects.
   Graph.prototype.addForeignObjectWarning = function(canvas, root) {
     // Do nothing.
   }

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -993,7 +993,7 @@ define('diagram-link-editor', [
           // less accurate.
           var containerWidth = this.state.initialWidth;
           var prevNode = $(fo.parentNode).prev()[0];
-          if (prevNode.nodeName == 'rect') {
+          if (prevNode &amp;&amp; prevNode.nodeName == 'rect') {
             var containerWidth = prevNode.width.baseVal.valueAsString;
           }
           try {
@@ -1247,6 +1247,9 @@ define('diagram-editor', [
   //
   var createDiagramEditor = function(options) {
     options = options || {};
+    // Todo: this is needed since we do not use drafts and it would create the file to soon, leading to the file being
+    // opened in a new window.
+    EditorUi.enableDrafts = false;
     var editor = new Editor(/* chromeless: */ uiTheme === 'min', options.themes, /* model: */ null, /* graph: */ null,
       /* editable: */ true);
     var editorUI = new App(editor, options.container);

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
@@ -274,6 +274,7 @@ define('diagram-setup', ['diagram-config'], function(diagramConfig) {
       'sanitizer': mxGraphEditorBasePath + 'sanitizer/sanitizer.min',
       'spin': drawIOBasePath + 'js/spin/spin.min',
       'jszip': drawIOBasePath + 'js/jszip/jszip.min',
+      'rough': drawIOBasePath + 'js/rough/rough.min',
       'mxgraph-init': drawIOBasePath + 'js/draw.io.init.min',
       'mxgraph-client': mxBasePath + 'mxClient.bundle.min',
       'mxgraph-editor': mxGraphEditorBasePath + 'mxGraphEditor.min',
@@ -286,7 +287,7 @@ define('diagram-setup', ['diagram-config'], function(diagramConfig) {
       'mxgraph-client': ['mxgraph-init'],
       'mxgraph-editor': ['mxgraph-client', 'jscolor', 'sanitizer'],
       'mxgraph-viewer': ['mxgraph-client', 'sanitizer'],
-      'draw.io': ['mxgraph-editor', 'base64', 'pako-global', 'spin-global', 'jszip-global'],
+      'draw.io': ['mxgraph-editor', 'base64', 'pako-global', 'spin-global', 'jszip-global', 'rough'],
       'draw.io.viewer': ['mxgraph-viewer', 'pako-global', 'spin-global'],
     }
   })

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
@@ -265,7 +265,6 @@ define('diagram-setup', ['diagram-config'], function(diagramConfig) {
   window.DriveLibrary = window.DropboxLibrary = window.GitHubLibrary = window.OneDriveLibrary = window.TrelloLibrary
     = false;
 
-  var suffix = diagramConfig.debug ? '' : '.min';
   var mxGraphEditorBasePath = diagramConfig.mxGraphEditorBasePath;
   require.config({
     paths: {
@@ -275,12 +274,12 @@ define('diagram-setup', ['diagram-config'], function(diagramConfig) {
       'sanitizer': mxGraphEditorBasePath + 'sanitizer/sanitizer.min',
       'spin': drawIOBasePath + 'js/spin/spin.min',
       'jszip': drawIOBasePath + 'js/jszip/jszip.min',
-      'mxgraph-init': drawIOBasePath + 'js/draw.io.init' + suffix,
-      'mxgraph-client': mxBasePath + 'mxClient.bundle' + suffix,
-      'mxgraph-editor': mxGraphEditorBasePath + 'mxGraphEditor' + suffix,
-      'mxgraph-viewer': mxGraphEditorBasePath + 'mxGraphViewer' + suffix,
-      'draw.io': drawIOBasePath + 'js/draw.io' + suffix,
-      'draw.io.viewer': drawIOBasePath + 'js/draw.io.viewer' + suffix,
+      'mxgraph-init': drawIOBasePath + 'js/draw.io.init.min',
+      'mxgraph-client': mxBasePath + 'mxClient.bundle.min',
+      'mxgraph-editor': mxGraphEditorBasePath + 'mxGraphEditor.min',
+      'mxgraph-viewer': mxGraphEditorBasePath + 'mxGraphViewer.min',
+      'draw.io': drawIOBasePath + 'js/draw.io.min',
+      'draw.io.viewer': drawIOBasePath + 'js/draw.io.viewer.min',
       'resourceSelector': new XWiki.Document('WebHome', 'Diagram.ResourceSelector').getURL('jsx', 'minify=' + !diagramConfig.debug)
     },
     shim: {

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <tag>HEAD</tag>
   </scm>
   <properties>
-    <draw.io.version>12.3.3-2</draw.io.version>
+    <draw.io.version>14.4.3-SNAPSHOT</draw.io.version>
     <licensing.version>1.16.1</licensing.version>
   </properties>
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <tag>HEAD</tag>
   </scm>
   <properties>
-    <draw.io.version>14.4.3-SNAPSHOT</draw.io.version>
+    <draw.io.version>14.4.3</draw.io.version>
     <licensing.version>1.16.1</licensing.version>
   </properties>
   <modules>


### PR DESCRIPTION
* upgrade dependency
* we don't need to change the '.min' extension manually since the new webjar contains also the map for the minified files, so the unminifying process is done automatically by the browser
* fix the start step by disabling the checkDrafts option, since a pop-up appeared for opening the file in a new window
* rough library is needed for some shapes from the sidebar
* loadUrl was moved from EditorUi; changed it to make import from URL to work
* hideFooter was removed from the code base
* toggleCompactMode parameter was changed from _forceHide_ to _visible_