### PR TITLE
Problems with updating diagram content when paths of linked pages exceed 255 characters #193

### DIFF
--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramLinksListener.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramLinksListener.java
@@ -37,7 +37,6 @@ import org.xwiki.observation.event.Event;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
-import com.xpn.xwiki.doc.XWikiLink;
 import com.xpn.xwiki.store.XWikiHibernateBaseStore.HibernateCallback;
 import com.xwiki.diagram.internal.handlers.DiagramContentHandler;
 import com.xwiki.diagram.internal.handlers.StoreHandler;
@@ -94,11 +93,10 @@ public class DiagramLinksListener extends AbstractEventListener
                         // Is necessary to blank links from doc.
                         context.remove("links");
 
-                        // Get pages linked by this diagram.
+                        // Add backlinks from pages linked by this diagram.
                         for (DocumentReference linkedDocRef : contentHandler.getLinkedPages(document.getContent(),
                             document.getDocumentReference())) {
-                            XWikiLink wikiLink = storeHandler.getXWikiLink(document, linkedDocRef);
-                            session.save(wikiLink);
+                            storeHandler.addXWikiLink(session, document, linkedDocRef);
                         }
 
                         return Boolean.TRUE;

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramMacroListener.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramMacroListener.java
@@ -42,14 +42,13 @@ import org.xwiki.rendering.block.match.MacroBlockMatcher;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
-import com.xpn.xwiki.doc.XWikiLink;
 import com.xpn.xwiki.store.XWikiHibernateBaseStore.HibernateCallback;
 import com.xwiki.diagram.internal.handlers.StoreHandler;
 
 /**
- * Listens to created or updated pages, checks for Diagram Macro and adds backlink from the diagram referenced to
- * this page. The backlink is used in order to update the reference parameter of the diagram macro in case of diagram
- * page rename.
+ * Listens to created or updated pages, checks for Diagram Macro and adds backlink from the diagram referenced to this
+ * page. The backlink is used in order to update the reference parameter of the diagram macro in case of diagram page
+ * rename.
  * 
  * @version $Id$
  * @since 1.13.1
@@ -107,8 +106,7 @@ public class DiagramMacroListener extends AbstractEventListener
                             DocumentReference macroReference = explicitDocumentReferenceResolver
                                 .resolve(macroBlock.getParameter("reference"), document.getDocumentReference());
 
-                            XWikiLink wikiLink = storeHandler.getXWikiLink(document, macroReference);
-                            session.save(wikiLink);
+                            storeHandler.addXWikiLink(session, document, macroReference);
                         }
 
                         return Boolean.TRUE;

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/DiagramContentHandler.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/DiagramContentHandler.java
@@ -67,7 +67,7 @@ public class DiagramContentHandler
     public static final LocalDocumentReference DIAGRAM_CLASS = new LocalDocumentReference("Diagram", "DiagramClass");
 
     @Inject
-    private GetDiagramLinksHandler getDiagramLinksHandler;
+    private Provider<GetDiagramLinksHandler> getDiagramLinksHandlerProvider;
 
     @Inject
     private DiagramLinkHandler linkHandler;
@@ -174,8 +174,7 @@ public class DiagramContentHandler
     public List<DocumentReference> getLinkedPages(String content, DocumentReference diagramReference)
     {
         try {
-            getDiagramLinksHandler.resetLinkedPages();
-
+            GetDiagramLinksHandler getDiagramLinksHandler = getDiagramLinksHandlerProvider.get();
             SAXParserFactory.newInstance().newSAXParser().parse(new ByteArrayInputStream(content.getBytes()),
                 getDiagramLinksHandler);
 

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/DiagramContentHandler.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/DiagramContentHandler.java
@@ -174,6 +174,8 @@ public class DiagramContentHandler
     public List<DocumentReference> getLinkedPages(String content, DocumentReference diagramReference)
     {
         try {
+            getDiagramLinksHandler.resetLinkedPages();
+
             SAXParserFactory.newInstance().newSAXParser().parse(new ByteArrayInputStream(content.getBytes()),
                 getDiagramLinksHandler);
 

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/GetDiagramLinksHandler.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/GetDiagramLinksHandler.java
@@ -77,4 +77,12 @@ public class GetDiagramLinksHandler extends DefaultHandler
         return linkedPages.stream().distinct().map(link -> resolver.resolve(link, diagramReference))
             .collect(Collectors.toList());
     }
+
+    /**
+     * Clear linked pages of other documents.
+     */
+    public void resetLinkedPages()
+    {
+        this.linkedPages = new ArrayList<String>();
+    }
 }

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/GetDiagramLinksHandler.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/GetDiagramLinksHandler.java
@@ -25,12 +25,13 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.inject.Singleton;
 
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 import org.xwiki.component.annotation.Component;
+import org.xwiki.component.annotation.InstantiationStrategy;
+import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
 
@@ -41,7 +42,7 @@ import org.xwiki.model.reference.DocumentReferenceResolver;
  * @since 1.13
  */
 @Component(roles = GetDiagramLinksHandler.class)
-@Singleton
+@InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 public class GetDiagramLinksHandler extends DefaultHandler
 {
     @Inject
@@ -76,13 +77,5 @@ public class GetDiagramLinksHandler extends DefaultHandler
     {
         return linkedPages.stream().distinct().map(link -> resolver.resolve(link, diagramReference))
             .collect(Collectors.toList());
-    }
-
-    /**
-     * Clear linked pages of other documents.
-     */
-    public void resetLinkedPages()
-    {
-        this.linkedPages = new ArrayList<String>();
     }
 }


### PR DESCRIPTION
* don't add the link if the limit is exceeded
* reset the value of linkedPaged before each diagram parsing, to be sure that it contains only the current document links