### PR TITLE
SVG import is not working #199

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1101,8 +1101,8 @@ define('diagram-link-editor', [
   };
 
   /**
-   * This function is copied from https://github.com/jgraph/drawio/blob/dev/src/main/webapp/js/grapheditor/Graph.js#L1592
-   * as a workaround for importing svg content. This needs to be deleted once the deprecated mxgraph will be replaced by
+   * TODO: This function is copied from https://github.com/jgraph/drawio/blob/dev/src/main/webapp/js/grapheditor/Graph.js
+   * as a workaround for importing svg content and needs to be deleted once the deprecated mxgraph will be replaced by
    * draw.io's grapheditor code.
    */
   Graph.clipSvgDataUri = function(dataUri) {
@@ -1158,7 +1158,7 @@ define('diagram-link-editor', [
   };
 
   /**
-   * Removes all script tags and attributes starting with on. This is needed by Graph.clipSvgDataUri and should be
+   * Removes all script tags and attributes starting with on. TODO: This is needed by Graph.clipSvgDataUri and should be
    * deleted along with it.
    */
   Graph.sanitizeSvg = function(div) {

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1099,6 +1099,89 @@ define('diagram-link-editor', [
       imgExport.drawState = originalDrawState;
     }
   };
+
+  /**
+   * This function is copied from https://github.com/jgraph/drawio/blob/dev/src/main/webapp/js/grapheditor/Graph.js#L1592
+   * as a workaround for importing svg content. This needs to be deleted once the deprecated mxgraph will be replaced by
+   * draw.io's grapheditor code.
+   */
+  Graph.clipSvgDataUri = function(dataUri) {
+    // LATER Add workaround for non-default NS declarations with empty URI not allowed in IE11.
+    if (!mxClient.IS_IE &amp;&amp; !mxClient.IS_IE11 &amp;&amp; dataUri != null &amp;&amp;
+        dataUri.substring(0, 26) == 'data:image/svg+xml;base64,') {
+      try {
+        var div = document.createElement('div');
+        div.style.position = 'absolute';
+        div.style.visibility = 'hidden';
+
+        // Adds the text and inserts into DOM for updating of size.
+        var data = decodeURIComponent(escape(atob(dataUri.substring(26))));
+        var idx = data.indexOf('&lt;svg');
+
+        if (idx &gt;= 0) {
+          // Strips leading XML declaration and doctypes.
+          div.innerHTML = data.substring(idx);
+
+          // Removes all attributes starting with on.
+          Graph.sanitizeSvg(div);
+
+          // Gets the size and removes from DOM.
+          var svgs = div.getElementsByTagName('svg');
+
+          if (svgs.length &gt; 0) {
+            document.body.appendChild(div);
+
+            try {
+              var size = svgs[0].getBBox();
+
+              if (size.width &gt; 0 &amp;&amp; size.height &gt; 0) {
+                div.getElementsByTagName('svg')[0].setAttribute('viewBox', size.x +
+                                                                ' ' + size.y + ' ' + size.width + ' ' + size.height);
+                div.getElementsByTagName('svg')[0].setAttribute('width', size.width);
+                div.getElementsByTagName('svg')[0].setAttribute('height', size.height);
+              }
+            } catch (e) {
+              // ignore
+            } finally {
+              document.body.removeChild(div);
+            }
+
+            dataUri = Editor.createSvgDataUri(mxUtils.getXml(svgs[0]));
+          }
+        }
+      } catch (e) {
+        // ignore
+      }
+    }
+
+    return dataUri;
+  };
+
+  /**
+   * Removes all script tags and attributes starting with on. This is needed by Graph.clipSvgDataUri and should be
+   * deleted along with it.
+   */
+  Graph.sanitizeSvg = function(div) {
+    // Removes all attributes starting with on.
+    var all = div.getElementsByTagName('*');
+
+    for (var i = 0; i &lt; all.length; i++) {
+      for (var j = 0; j &lt; all[i].attributes.length; j++) {
+        var attr = all[i].attributes[j];
+
+        if (attr.name.length &gt; 2 &amp;&amp; attr.name.toLowerCase().substring(0, 2) == 'on') {
+          all[i].removeAttribute(attr.name);
+        }
+      }
+    }
+
+    // Removes all script tags.
+    var scripts = div.getElementsByTagName('script');
+
+    while (scripts.length &gt; 0) {
+      scripts[0].parentNode.removeChild(scripts[0]);
+    }
+  };
 });
 
 /**


### PR DESCRIPTION
* the grapheditor code is used in recent version from drawio, instead of mxgraph; until the new code is added to the webjar,
as a workaround, the missing methods were added