### PR TITLE
Update grapheditor code #201

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1099,89 +1099,6 @@ define('diagram-link-editor', [
       imgExport.drawState = originalDrawState;
     }
   };
-
-  /**
-   * TODO: This function is copied from https://github.com/jgraph/drawio/blob/dev/src/main/webapp/js/grapheditor/Graph.js
-   * as a workaround for importing svg content and needs to be deleted once the deprecated mxgraph will be replaced by
-   * draw.io's grapheditor code.
-   */
-  Graph.clipSvgDataUri = function(dataUri) {
-    // LATER Add workaround for non-default NS declarations with empty URI not allowed in IE11.
-    if (!mxClient.IS_IE &amp;&amp; !mxClient.IS_IE11 &amp;&amp; dataUri != null &amp;&amp;
-        dataUri.substring(0, 26) == 'data:image/svg+xml;base64,') {
-      try {
-        var div = document.createElement('div');
-        div.style.position = 'absolute';
-        div.style.visibility = 'hidden';
-
-        // Adds the text and inserts into DOM for updating of size.
-        var data = decodeURIComponent(escape(atob(dataUri.substring(26))));
-        var idx = data.indexOf('&lt;svg');
-
-        if (idx &gt;= 0) {
-          // Strips leading XML declaration and doctypes.
-          div.innerHTML = data.substring(idx);
-
-          // Removes all attributes starting with on.
-          Graph.sanitizeSvg(div);
-
-          // Gets the size and removes from DOM.
-          var svgs = div.getElementsByTagName('svg');
-
-          if (svgs.length &gt; 0) {
-            document.body.appendChild(div);
-
-            try {
-              var size = svgs[0].getBBox();
-
-              if (size.width &gt; 0 &amp;&amp; size.height &gt; 0) {
-                div.getElementsByTagName('svg')[0].setAttribute('viewBox', size.x +
-                                                                ' ' + size.y + ' ' + size.width + ' ' + size.height);
-                div.getElementsByTagName('svg')[0].setAttribute('width', size.width);
-                div.getElementsByTagName('svg')[0].setAttribute('height', size.height);
-              }
-            } catch (e) {
-              // ignore
-            } finally {
-              document.body.removeChild(div);
-            }
-
-            dataUri = Editor.createSvgDataUri(mxUtils.getXml(svgs[0]));
-          }
-        }
-      } catch (e) {
-        // ignore
-      }
-    }
-
-    return dataUri;
-  };
-
-  /**
-   * Removes all script tags and attributes starting with on. TODO: This is needed by Graph.clipSvgDataUri and should be
-   * deleted along with it.
-   */
-  Graph.sanitizeSvg = function(div) {
-    // Removes all attributes starting with on.
-    var all = div.getElementsByTagName('*');
-
-    for (var i = 0; i &lt; all.length; i++) {
-      for (var j = 0; j &lt; all[i].attributes.length; j++) {
-        var attr = all[i].attributes[j];
-
-        if (attr.name.length &gt; 2 &amp;&amp; attr.name.toLowerCase().substring(0, 2) == 'on') {
-          all[i].removeAttribute(attr.name);
-        }
-      }
-    }
-
-    // Removes all script tags.
-    var scripts = div.getElementsByTagName('script');
-
-    while (scripts.length &gt; 0) {
-      scripts[0].parentNode.removeChild(scripts[0]);
-    }
-  };
 });
 
 /**
@@ -1372,17 +1289,24 @@ define('diagram-editor', [
   'diagram-store',
   'diagram-utils',
   'diagram-url-io',
+  'diagram-config',
   'diagram-graph-xml-filter',
   'diagram-link-editor',
   'diagram-image-editor',
   'diagram-external-services'
-], function($, diagramStore, diagramUtils, diagramUrlIO) {
+], function($, diagramStore, diagramUtils, diagramUrlIO, diagramConfig) {
 
   // These variables are used to decide if an image should be uploaded at original resolution or
   // should be declined for being too big.
   // Default values:
   // EditorUi.prototype.maxImageSize = 520;
   // EditorUi.prototype.maxImageBytes = 1000000;
+
+  // Add the required stylesheets, since on newer versions of mxClient the basePath of the stylesheets is not considered.
+  if (mxLoadStylesheets)
+  {
+    mxClient.link('stylesheet', mxClient.basePath + '/css/common.css');
+  }
 
   //
   // Diagram Editor Constructor.

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1303,8 +1303,7 @@ define('diagram-editor', [
   // EditorUi.prototype.maxImageBytes = 1000000;
 
   // Add the required stylesheets, since on newer versions of mxClient the basePath of the stylesheets is not considered.
-  if (mxLoadStylesheets)
-  {
+  if (mxLoadStylesheets) {
     mxClient.link('stylesheet', mxClient.basePath + '/css/common.css');
   }
 

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1289,12 +1289,11 @@ define('diagram-editor', [
   'diagram-store',
   'diagram-utils',
   'diagram-url-io',
-  'diagram-config',
   'diagram-graph-xml-filter',
   'diagram-link-editor',
   'diagram-image-editor',
   'diagram-external-services'
-], function($, diagramStore, diagramUtils, diagramUrlIO, diagramConfig) {
+], function($, diagramStore, diagramUtils, diagramUrlIO) {
 
   // These variables are used to decide if an image should be uploaded at original resolution or
   // should be declined for being too big.

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1302,11 +1302,6 @@ define('diagram-editor', [
   // EditorUi.prototype.maxImageSize = 520;
   // EditorUi.prototype.maxImageBytes = 1000000;
 
-  // Add the required stylesheets, since on newer versions of mxClient the basePath of the stylesheets is not considered.
-  if (mxLoadStylesheets) {
-    mxClient.link('stylesheet', mxClient.basePath + '/css/common.css');
-  }
-
   //
   // Diagram Editor Constructor.
   //

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
@@ -227,6 +227,8 @@ define('diagram-setup', ['diagram-config'], function(diagramConfig) {
   window.EXPORT_URL = diagramConfig.exportURL;
   window.PROXY_URL = new XWiki.Document('DiagramProxy', 'Diagram').getURL('get');
   window.isLocalStorage = true;
+  // mxClient is not considering the basePath of the stylesheet files, so we load them after.
+  window.mxLoadStylesheets = false;
 
   window.urlParams = (function(params) {
     var pairs = window.location.search.substr(1).split('&amp;');
@@ -792,6 +794,9 @@ define('diagram-utils', ['jquery', 'diagram-link-handler'], function($, diagramL
     });
     return result;
   };
+
+  // Add the required stylesheets, since in mxClient the basePath of the stylesheets is not considered.
+  mxClient.link('stylesheet', mxClient.basePath + '/css/common.css');
 
   return {
     getDiagramXMLFromURL: getDiagramXMLFromURL,

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
@@ -206,12 +206,13 @@ define('diagram-config', ['jquery'], function($) {
  * Diagram application setup.
  */
 define('diagram-setup', ['diagram-config'], function(diagramConfig) {
+  var drawIOBasePath = diagramConfig.drawIOBasePath;
   // mxGraph client setup
-  window.mxBasePath = diagramConfig.drawIOBasePath + '/mxgraph';
+  window.mxBasePath = drawIOBasePath + 'mxgraph';
+  window.mxImageBasePath = drawIOBasePath + 'mxgraph/images';
   window.mxLanguage = diagramConfig.locale;
 
   // draw.io setup
-  var drawIOBasePath = diagramConfig.drawIOBasePath;
   window.RESOURCES_PATH = drawIOBasePath + 'resources';
   window.RESOURCE_BASE = RESOURCES_PATH + '/dia';
   window.STENCIL_PATH = drawIOBasePath + 'stencils';

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
@@ -45,8 +45,6 @@
   #set ($diagramConfig = {
     "debug": $services.debug.minify.equals(false),
     "locale": $xcontext.locale,
-    "mxGraphClientBasePath": $services.webjars.url('org.xwiki.contrib:mxgraph-client', ''),
-    "mxGraphEditorBasePath": $services.webjars.url('org.xwiki.contrib:mxgraph-editor', ''),
     "drawIOBasePath": $services.webjars.url('org.xwiki.contrib:draw.io', ''),
     "exportURL": $xwiki.getDocument('Diagram.DiagramConfig').getValue('exportURL'),
     "pdfImageExportZoom": $diagramObj.getValue('pdfImageExportZoom'),
@@ -209,7 +207,7 @@ define('diagram-config', ['jquery'], function($) {
  */
 define('diagram-setup', ['diagram-config'], function(diagramConfig) {
   // mxGraph client setup
-  window.mxBasePath = diagramConfig.mxGraphClientBasePath;
+  window.mxBasePath = diagramConfig.drawIOBasePath + '/mxgraph';
   window.mxLanguage = diagramConfig.locale;
 
   // draw.io setup
@@ -267,20 +265,19 @@ define('diagram-setup', ['diagram-config'], function(diagramConfig) {
   window.DriveLibrary = window.DropboxLibrary = window.GitHubLibrary = window.OneDriveLibrary = window.TrelloLibrary
     = false;
 
-  var mxGraphEditorBasePath = diagramConfig.mxGraphEditorBasePath;
   require.config({
     paths: {
-      'base64': mxGraphEditorBasePath + 'deflate/base64.min',
-      'jscolor': mxGraphEditorBasePath + 'jscolor/jscolor.min',
-      'pako': mxGraphEditorBasePath + 'deflate/pako.min',
-      'sanitizer': mxGraphEditorBasePath + 'sanitizer/sanitizer.min',
+      'base64': drawIOBasePath + 'js/deflate/base64.min',
+      'jscolor': drawIOBasePath + 'js/jscolor/jscolor.min',
+      'pako': drawIOBasePath + 'js/deflate/pako.min',
+      'sanitizer': drawIOBasePath + 'js/sanitizer/sanitizer.min',
       'spin': drawIOBasePath + 'js/spin/spin.min',
       'jszip': drawIOBasePath + 'js/jszip/jszip.min',
       'rough': drawIOBasePath + 'js/rough/rough.min',
       'mxgraph-init': drawIOBasePath + 'js/draw.io.init.min',
-      'mxgraph-client': mxBasePath + 'mxClient.bundle.min',
-      'mxgraph-editor': mxGraphEditorBasePath + 'mxGraphEditor.min',
-      'mxgraph-viewer': mxGraphEditorBasePath + 'mxGraphViewer.min',
+      'mxgraph-client': drawIOBasePath + 'mxgraph/mxClient',
+      'mxgraph-editor': drawIOBasePath + 'js/draw.io.grapheditor.min',
+      'mxgraph-viewer': drawIOBasePath + 'js/draw.io.graphviewer.min',
       'draw.io': drawIOBasePath + 'js/draw.io.min',
       'draw.io.viewer': drawIOBasePath + 'js/draw.io.viewer.min',
       'resourceSelector': new XWiki.Document('WebHome', 'Diagram.ResourceSelector').getURL('jsx', 'minify=' + !diagramConfig.debug)

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -175,11 +175,6 @@
     return origin;
   };
 
-  // Add the required stylesheets, since on newer versions of mxClient the basePath of the stylesheets is not considered.
-  if (mxLoadStylesheets) {
-    mxClient.link('stylesheet', mxClient.basePath + '/css/common.css');
-  }
-
   // This is required for the clipart images.
   GraphViewer.prototype.imageBaseUrl = getOrigin();
 

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -175,6 +175,11 @@
     return origin;
   };
 
+  // Add the required stylesheets, since on newer versions of mxClient the basePath of the stylesheets is not considered.
+  if (mxLoadStylesheets) {
+    mxClient.link('stylesheet', mxClient.basePath + '/css/common.css');
+  }
+
   // This is required for the clipart images.
   GraphViewer.prototype.imageBaseUrl = getOrigin();
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <tag>HEAD</tag>
   </scm>
   <properties>
-    <draw.io.version>14.4.3-1</draw.io.version>
+    <draw.io.version>14.4.3-2</draw.io.version>
     <licensing.version>1.16.1</licensing.version>
   </properties>
   <modules>


### PR DESCRIPTION
* updated paths to the new grapheditor, graphviewer and mxClient code
* update path to grapheditor images
* load mxClient stylesheet, for editor and viewer, since in the new added code the basePath is not considered

A problem brought by this is that the new mxClient code only has a minified version, being harder to debug now. 