### PR TITLE
Errors after creating and when trying to save diagrams on mobile #210

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1346,9 +1346,12 @@ define('diagram-editor', [
   var fixEditorUI = function(editorUI) {
     cleanMenu(editorUI);
     fixKeyboardShortcutsAction(editorUI);
-    removeCompactModeToggle(editorUI);
-    fixFullScreenToggle(editorUI);
     fixEditorButtons($(editorUI.container));
+    // These are not present on mobile.
+    if (editorUI.menubar != null) {
+      removeCompactModeToggle(editorUI);
+      fixFullScreenToggle(editorUI);
+    }
   };
 
   var fixLoadUrl = function(editorUI) {


### PR DESCRIPTION
* avoid some method calls on mobile since the targeted ui elements are not present on that view mode
* the same is done on drawio https://github.com/jgraph/drawio/blob/dev/src/main/webapp/js/diagramly/App.js#L6750