### PR TITLE
Caching problems after version upgrade #238

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -74,6 +74,9 @@
   ## editor doesn't use standard text fields for entering the labels for the various shapes the diagram is made of)
   #set ($keyboardShortcutsEnabled = false)
   #set ($discard = $xwiki.ssx.use('Diagram.DiagramSheet'))
+  ## Make sure that the version loaded with RequireJS is not a cached one. See XWIKI-12981: Add the document version
+  ## of skin extensions in the generated URLs.
+  #set ($discard = $xwiki.jsx.use('Diagram.DiagramSheet'))
   #set ($discard = $xwiki.jsx.use('Diagram.DiagramEditSheet'))
   ## Issue #219: Cannot modify diagram title in diagram editor
   &lt;div class="row xform"&gt;

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -74,9 +74,6 @@
   ## editor doesn't use standard text fields for entering the labels for the various shapes the diagram is made of)
   #set ($keyboardShortcutsEnabled = false)
   #set ($discard = $xwiki.ssx.use('Diagram.DiagramSheet'))
-  ## Make sure that the version loaded with RequireJS is not a cached one. See XWIKI-12981: Add the document version
-  ## of skin extensions in the generated URLs.
-  #set ($discard = $xwiki.jsx.use('Diagram.DiagramSheet'))
   #set ($discard = $xwiki.jsx.use('Diagram.DiagramEditSheet'))
   ## Issue #219: Cannot modify diagram title in diagram editor
   &lt;div class="row xform"&gt;
@@ -1708,9 +1705,22 @@ define('diagram-editor', [
       <cache>long</cache>
     </property>
     <property>
-      <code>require.config({
+      <code>/*!
+## Make sure that the version loaded with RequireJS is not a cached one.
+#set ($version = $services.extension.installed.getInstalledExtension('com.xwiki.diagram:application-diagram',
+  "wiki:$xcontext.database").version.value)
+#set ($params = $escapetool.url({
+  'minify': $!services.debug.minify,
+  'appVersion': $version
+}))
+#[[*/
+// Start JavaScript-only code.
+(function(params) {
+  "use strict";
+
+require.config({
   paths: {
-    'diagram-setup': new XWiki.Document('DiagramSheet', 'Diagram').getURL('jsx', 'minify=$!services.debug.minify')
+    'diagram-setup': new XWiki.Document('DiagramSheet', 'Diagram').getURL('jsx', params)
   },
   map: {
     'diagram-utils': {
@@ -1728,7 +1738,10 @@ require(['diagram-setup'], function() {
       $('.diagram-editor').editDiagram();
     });
   });
-});</code>
+});
+
+// End JavaScript-only code.
+}).apply(']]#', $jsontool.serialize([$params]));</code>
     </property>
     <property>
       <name>Startup</name>

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -40,6 +40,9 @@
 #set ($diagramObj = $doc.getObject('Diagram.DiagramClass'))
 #if ($diagramObj || "$!request.source" != '')
   #set ($discard = $xwiki.ssx.use('Diagram.DiagramSheet'))
+  ## Make sure that the version loaded with RequireJS is not a cached one. See XWIKI-12981: Add the document version
+  ## of skin extensions in the generated URLs.
+  #set ($discard = $xwiki.jsx.use('Diagram.DiagramSheet'))
   #set ($discard = $xwiki.jsx.use('Diagram.DiagramViewSheet'))
   #set ($toolbar = 'zoom layers pages lightbox')
   #if ("$!request.source" == '' &amp;&amp; $services.security.authorization.hasAccess('edit'))

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -40,9 +40,6 @@
 #set ($diagramObj = $doc.getObject('Diagram.DiagramClass'))
 #if ($diagramObj || "$!request.source" != '')
   #set ($discard = $xwiki.ssx.use('Diagram.DiagramSheet'))
-  ## Make sure that the version loaded with RequireJS is not a cached one. See XWIKI-12981: Add the document version
-  ## of skin extensions in the generated URLs.
-  #set ($discard = $xwiki.jsx.use('Diagram.DiagramSheet'))
   #set ($discard = $xwiki.jsx.use('Diagram.DiagramViewSheet'))
   #set ($toolbar = 'zoom layers pages lightbox')
   #if ("$!request.source" == '' &amp;&amp; $services.security.authorization.hasAccess('edit'))
@@ -411,9 +408,22 @@
       <cache>long</cache>
     </property>
     <property>
-      <code>require.config({
+      <code>/*!
+## Make sure that the version loaded with RequireJS is not a cached one.
+#set ($version = $services.extension.installed.getInstalledExtension('com.xwiki.diagram:application-diagram',
+  "wiki:$xcontext.database").version.value)
+#set ($params = $escapetool.url({
+  'minify': $!services.debug.minify,
+  'appVersion': $version
+}))
+#[[*/
+// Start JavaScript-only code.
+(function(params) {
+  "use strict";
+
+require.config({
   paths: {
-    'diagram-setup': new XWiki.Document('DiagramSheet', 'Diagram').getURL('jsx', 'minify=$!services.debug.minify')
+    'diagram-setup': new XWiki.Document('DiagramSheet', 'Diagram').getURL('jsx', params)
   },
   map: {
     'diagram-utils': {
@@ -431,7 +441,10 @@ require(['diagram-setup'], function() {
       $('.diagram').viewDiagram();
     });
   });
-});</code>
+});
+
+// End JavaScript-only code.
+}).apply(']]#', $jsontool.serialize([$params]));</code>
     </property>
     <property>
       <name>Startup</name>


### PR DESCRIPTION
* make sure that the version loaded with RequireJS (e.g. [here](https://github.com/xwikisas/application-diagram/blob/master/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml#L1710)) is not a cached one ; for this, `Diagram.DiagramSheet` is loaded first using `$xwiki.jsx.use` in order to use the fix from https://jira.xwiki.org/browse/XWIKI-12981