### PR TITLE
Warning message when creating a diagram from an existing page using the {{diagram/}} macro #279

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
@@ -301,7 +301,8 @@
 #macro (createDiagram $reference)
   {{html clean="false"}}
   #set ($createURL = $xwiki.getURL($reference, 'edit', $escapetool.url({
-    'template': 'Diagram.DiagramTemplate'
+    'template': 'Diagram.DiagramTemplate',
+    'form_token': $escapetool.xml($services.csrf.token)
   })))
   &lt;div&gt;
     &lt;a class="diagram-create btn btn-default" href="$createURL"&gt;


### PR DESCRIPTION
Added the csrf token as a parameter to the diagram creation button.