### PR TITLE
 Links in the diagram aren't updated when the linked pages are moved/renamed #245 

### DIFF
--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/URLResolver.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/URLResolver.java
@@ -48,7 +48,7 @@ import com.xpn.xwiki.XWikiContext;
 import liquibase.repackaged.org.apache.commons.lang3.exception.ExceptionUtils;
 
 /**
- * Handles the transformation link into XWiki references
+ * Handles the transformation link into XWiki references.
  *
  * @version $Id$
  * @since 1.13
@@ -75,16 +75,16 @@ public class URLResolver
     private EntityReferenceResolver<String> defaultStringResolver;
 
     /**
-     * Transforms an URL to a XWiki reference
-     * @param URL URL of the page
+     * Transforms an URL to a XWiki reference.
+     * @param url URL of the page
      * @param type of the reference
      * @return an entity reference
      */
-    public EntityReference getReferenceFromXWikiLink(String URL, EntityType type)
+    public EntityReference getReferenceFromXWikiLink(String url, EntityType type)
     {
         XWikiContext xcontext = this.xcontextProvider.get();
         try {
-            ExtendedURL extendedURL = new ExtendedURL(new URL(URL), xcontext.getRequest().getContextPath());
+            ExtendedURL extendedURL = new ExtendedURL(new URL(url), xcontext.getRequest().getContextPath());
             ResourceType resourceType = this.typeResolver.resolve(extendedURL, Collections.emptyMap());
             ResourceReference reference =
                 this.resourceResolver.resolve(extendedURL, resourceType, Collections.emptyMap());
@@ -96,9 +96,9 @@ public class URLResolver
                  | UnsupportedResourceReferenceException
                  | CreateResourceTypeException
                  | MalformedURLException e) {
-            logger.warn("Failed to extract an EntityReference from [{}]. Root cause is [{}].", URL,
+            logger.warn("Failed to extract an EntityReference from [{}]. Root cause is [{}].", url,
                 ExceptionUtils.getRootCauseMessage(e));
         }
-        return defaultStringResolver.resolve(URL, type);
+        return defaultStringResolver.resolve(url, type);
     }
 }

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/URLResolver.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/URLResolver.java
@@ -1,0 +1,104 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.diagram.internal.handlers;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.EntityType;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.EntityReferenceResolver;
+import org.xwiki.resource.CreateResourceReferenceException;
+import org.xwiki.resource.CreateResourceTypeException;
+import org.xwiki.resource.ResourceReference;
+import org.xwiki.resource.ResourceReferenceResolver;
+import org.xwiki.resource.ResourceType;
+import org.xwiki.resource.ResourceTypeResolver;
+import org.xwiki.resource.UnsupportedResourceReferenceException;
+import org.xwiki.resource.entity.EntityResourceReference;
+import org.xwiki.url.ExtendedURL;
+
+import com.xpn.xwiki.XWikiContext;
+
+import liquibase.repackaged.org.apache.commons.lang3.exception.ExceptionUtils;
+
+/**
+ * Handles the transformation link into XWiki references
+ *
+ * @version $Id$
+ * @since 1.13
+ */
+@Component(roles = URLResolver.class)
+@Singleton
+public class URLResolver
+{
+    @Inject
+    private Provider<XWikiContext> xcontextProvider;
+
+    @Inject
+    @Named("standard")
+    private ResourceReferenceResolver<ExtendedURL> resourceResolver;
+
+    @Inject
+    @Named("standard")
+    private ResourceTypeResolver<ExtendedURL> typeResolver;
+
+    @Inject
+    private Logger logger;
+
+    @Inject
+    private EntityReferenceResolver<String> defaultStringResolver;
+
+    /**
+     * Transforms an URL to a XWiki reference
+     * @param URL URL of the page
+     * @param type of the reference
+     * @return an entity reference
+     */
+    public EntityReference getReferenceFromXWikiLink(String URL, EntityType type)
+    {
+        XWikiContext xcontext = this.xcontextProvider.get();
+        try {
+            ExtendedURL extendedURL = new ExtendedURL(new URL(URL), xcontext.getRequest().getContextPath());
+            ResourceType resourceType = this.typeResolver.resolve(extendedURL, Collections.emptyMap());
+            ResourceReference reference =
+                this.resourceResolver.resolve(extendedURL, resourceType, Collections.emptyMap());
+            if (reference instanceof EntityResourceReference) {
+                EntityReference entityReference = ((EntityResourceReference) reference).getEntityReference();
+                return entityReference;
+            }
+        } catch (CreateResourceReferenceException
+                 | UnsupportedResourceReferenceException
+                 | CreateResourceTypeException
+                 | MalformedURLException e) {
+            logger.warn("Failed to extract an EntityReference from [{}]. Root cause is [{}].", URL,
+                ExceptionUtils.getRootCauseMessage(e));
+        }
+        return defaultStringResolver.resolve(URL, type);
+    }
+}

--- a/application-diagram-api/src/main/resources/META-INF/components.txt
+++ b/application-diagram-api/src/main/resources/META-INF/components.txt
@@ -12,3 +12,4 @@ com.xwiki.diagram.internal.handlers.DiagramLinkHandler
 com.xwiki.diagram.internal.handlers.StoreHandler
 com.xwiki.diagram.internal.DiagramMacroListener
 com.xwiki.diagram.script.DiagramScriptService
+com.xwiki.diagram.internal.handlers.URLResolver


### PR DESCRIPTION
Diagram 13.10 format of storing links
```
<mxGraphModel dx="675" dy="497" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
  <root>
    <mxCell id="02RGCM9eTaJ_NC1oTMjw-0"/>
    <mxCell id="02RGCM9eTaJ_NC1oTMjw-1" parent="02RGCM9eTaJ_NC1oTMjw-0"/>
    <UserObject label="doc:xwiki:Sandbox.TestPage1" link="data:xwiki/reference,doc:xwiki:Sandbox.TestPage1" id="4VBxEF4AdllXUBW6Tvul-2">
      <mxCell style="fontColor=#0000EE;fontStyle=4;rounded=1;overflow=hidden;spacing=10;" vertex="1" parent="02RGCM9eTaJ_NC1oTMjw-1">
        <mxGeometry x="260" y="90" width="190" height="40" as="geometry"/>
      </mxCell>
    </UserObject>
  </root>
</mxGraphModel>
```

Latest version
```
<mxfile host="127.0.0.1" modified="2024-10-21T12:12:24.879Z" agent="5.0 (X11; Ubuntu)" version="@DRAWIO-VERSION@" etag="BGTIINEsXoovYjZ-Xa0L" type="xwiki">
  <diagram id="LCEc79ZTtFtL4sA867KB" name="Page-1">
    <mxGraphModel dx="675" dy="459" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
      <root>
        <mxCell id="2FxwDMMO4RY1L_b9vJ6J-0" />
        <mxCell id="2FxwDMMO4RY1L_b9vJ6J-1" parent="2FxwDMMO4RY1L_b9vJ6J-0" />
        <UserObject label="doc:xwiki:Sandbox.TestPage3" link="http://127.0.0.1:8080/xwiki/bin/view/Sandbox/TestPage3" id="IFuU3dNwXReG22dAsHCj-2">
          <mxCell style="fontColor=#0000EE;fontStyle=4;rounded=1;overflow=hidden;spacing=10;" vertex="1" parent="2FxwDMMO4RY1L_b9vJ6J-1">
            <mxGeometry x="250" y="230" width="200" height="40" as="geometry" />
          </mxCell>
        </UserObject>
      </root>
    </mxGraphModel>
  </diagram>
</mxfile>
```