### PR TITLE
 The diagram macro doesn't follow the naming strategy when creating a diagram #292

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
@@ -313,8 +313,10 @@
 
 #macro (executeDiagramMacro)
   #set ($reference = $xcontext.macro.params.reference)
+  #set ($reference = $services.modelvalidation.transformName($reference))
   #if ($stringtool.isEmpty($reference))
-    #set ($reference = $services.model.createDocumentReference('Diagram', $doc.documentReference.parent))
+    #set ($validName = $services.modelvalidation.transformName('Diagram'))
+    #set ($reference = $services.model.createDocumentReference($validName, $doc.documentReference.parent))
   #else
     #set ($reference = $services.model.resolveDocument($reference))
   #end


### PR DESCRIPTION
Updated the code to transform the name of the diagram using the current naming strategy.