### PR TITLE
"Unknown error" when clicking on the vertical ellipsis " ⋮ " #286

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1396,8 +1396,8 @@ define('diagram-editor', [
   var originalAddSubmenu = Menus.prototype.addSubmenu;
   Menus.prototype.addSubmenu = function(name, menu, parent, label) {
     var subMenu = this.get(name);
-    if (subMenu &amp;&amp; subMenu.visible !== false) {
-      originalAddSubmenu.apply(this, arguments);
+    if (subMenu &amp;&amp; subMenu.isEnabled() !== false) {
+     return originalAddSubmenu.apply(this, arguments);
     }
   };
 


### PR DESCRIPTION
In draw.io version 20.8.0, the method responsible for the submenu changed slightly, and now it returns the submenu. This issue occurred because our function did not return the submenu, which could later lead to a type error.