### PR TITLE
 Error when clicking several times on More Results #285 

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1396,8 +1396,8 @@ define('diagram-editor', [
   var originalAddSubmenu = Menus.prototype.addSubmenu;
   Menus.prototype.addSubmenu = function(name, menu, parent, label) {
     var subMenu = this.get(name);
-    if (subMenu &amp;&amp; subMenu.visible !== false) {
-      originalAddSubmenu.apply(this, arguments);
+    if (subMenu &amp;&amp; subMenu.isEnabled() !== false) {
+     return originalAddSubmenu.apply(this, arguments);
     }
   };
 

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1396,8 +1396,8 @@ define('diagram-editor', [
   var originalAddSubmenu = Menus.prototype.addSubmenu;
   Menus.prototype.addSubmenu = function(name, menu, parent, label) {
     var subMenu = this.get(name);
-    if (subMenu &amp;&amp; subMenu.isEnabled() !== false) {
-     return originalAddSubmenu.apply(this, arguments);
+    if (subMenu &amp;&amp; subMenu.visible !== false) {
+      originalAddSubmenu.apply(this, arguments);
     }
   };
 

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
@@ -251,6 +251,7 @@ define('diagram-setup', ['diagram-config'], function(diagramConfig) {
   window.mxLanguage = diagramConfig.locale;
 
   // draw.io setup
+  window.DRAWIO_SERVER_URL = "https://app.diagrams.net/";
   window.RESOURCES_PATH = drawIOBasePath + 'resources';
   window.RESOURCE_BASE = RESOURCES_PATH + '/dia';
   window.STENCIL_PATH = drawIOBasePath + 'stencils';


### PR DESCRIPTION
 In version 22.0.0, draw.io updated the way it computes the icon path and now it relies on a new global variable called DRAWIO_SERVER_URL, which is based on the current server address. Due to this change, requests intended fordraw.io are mistakenly made locally instead of to the external draw.io server

https://github.com/jgraph/drawio/blame/acd938b1e42cff3be3b629e6239cdec9a9baddcc/src/main/webapp/js/diagramly/Init.js#L51

https://github.com/jgraph/drawio/blame/acd938b1e42cff3be3b629e6239cdec9a9baddcc/src/main/webapp/js/diagramly/Init.js#L25