### PR TITLE
 XWiki export doesn't work properly when a diagram is present. #311

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
@@ -269,12 +269,6 @@
             &amp;&amp; $diagram.getAttachment($pngFileName))
           #set ($fileName = $pngFileName)
         #elseif ($xcontext.action == 'export')
-          #set ($reference = $xcontext.macro.params.reference)
-          #if ($stringtool.isEmpty($reference))
-            #set ($reference = $services.model.createDocumentReference('Diagram', $doc.documentReference.parent))
-          #else
-            #set ($reference = $services.model.resolveDocument($reference))
-          #end
           #set ($diagram = $xwiki.getDocument($reference))
           #set ($output = "{{html}}&lt;div&gt;$diagram.getAttachment('diagram.svg').getContentAsString()&lt;/div&gt;{{/html}}")
         #else

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
@@ -268,10 +268,13 @@
         #if ($xcontext.action == 'export' &amp;&amp; $diagramObj.getValue('exportUsingSVG') == 0
             &amp;&amp; $diagram.getAttachment($pngFileName))
           #set ($fileName = $pngFileName)
+          #set ($diagramURL = $diagram.getAttachmentURL($fileName, 'download', "v=$!diagram.version"))
+          #set ($output = "{{html clean='false'}}&lt;img src='$diagramURL' alt='$escapetool.xml($diagramTitle)'/&gt;{{/html}}")
         #elseif ($xcontext.action == 'export')
           #set ($diagram = $xwiki.getDocument($reference))
           #set ($output = "{{html}}&lt;div&gt;$diagram.getAttachment('diagram.svg').getContentAsString()&lt;/div&gt;{{/html}}")
         #else
+          ## If we reached this branch it means that we are in 'view' mode, and we should use the svg.
           #set ($diagramURL = $diagram.getAttachmentURL($fileName, 'download', "v=$!diagram.version"))
           #set ($output = "{{html clean='false'}}&lt;img src='$diagramURL' alt='$escapetool.xml($diagramTitle)'/&gt;{{/html}}")
         #end

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
@@ -268,9 +268,19 @@
         #if ($xcontext.action == 'export' &amp;&amp; $diagramObj.getValue('exportUsingSVG') == 0
             &amp;&amp; $diagram.getAttachment($pngFileName))
           #set ($fileName = $pngFileName)
+        #elseif ($xcontext.action == 'export')
+          #set ($reference = $xcontext.macro.params.reference)
+          #if ($stringtool.isEmpty($reference))
+            #set ($reference = $services.model.createDocumentReference('Diagram', $doc.documentReference.parent))
+          #else
+            #set ($reference = $services.model.resolveDocument($reference))
+          #end
+          #set ($diagram = $xwiki.getDocument($reference))
+          #set ($output = "{{html}}&lt;div&gt;$diagram.getAttachment('diagram.svg').getContentAsString()&lt;/div&gt;{{/html}}")
+        #else
+          #set ($diagramURL = $diagram.getAttachmentURL($fileName, 'download', "v=$!diagram.version"))
+          #set ($output = "{{html clean='false'}}&lt;img src='$diagramURL' alt='$escapetool.xml($diagramTitle)'/&gt;{{/html}}")
         #end
-        #set ($diagramURL = $diagram.getAttachmentURL($fileName, 'download', "v=$!diagram.version"))
-        #set ($output = "{{html clean='false'}}&lt;img src='$diagramURL' alt='$escapetool.xml($diagramTitle)'/&gt;{{/html}}")
       #else
         #set ($output = "{{display reference='$services.rendering.escape($reference, $xcontext.macro.doc.syntax)' /}}")
         #set ($showCaption = false)

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -47,15 +47,13 @@
   #end
   {{html clean="false"}}
   ## Check if the query contains the parameter for getting the diagram from URL.
-
-  #set ($dispalyDiv = "show")
-  #if ($xcontext.action == "export")
-    #set ($displayDiv  =  "hidden")
+  #set ($displayDiv = "")
+  #if ($xcontext.action == 'export')
+    #set ($displayDiv  =  'hidden')
     &lt;div&gt;
-        $doc.getAttachment('diagram.svg').getContentAsString()
+      $doc.getAttachment('diagram.svg').getContentAsString()
     &lt;div&gt;
   #end
-
   &lt;div class="diagram $displayDiv"
     data-diagram-config="$escapetool.xml($jsontool.serialize($diagramConfig))"
     data-toolbar="$escapetool.xml($toolbar)"

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -47,7 +47,16 @@
   #end
   {{html clean="false"}}
   ## Check if the query contains the parameter for getting the diagram from URL.
-  &lt;div class="diagram"
+
+  #set ($dispalyDiv = "show")
+  #if ($xcontext.action == "export")
+    #set ($displayDiv  =  "hidden")
+    &lt;div&gt;
+        $doc.getAttachment('diagram.svg').getContentAsString()
+    &lt;div&gt;
+  #end
+
+  &lt;div class="diagram $displayDiv"
     data-diagram-config="$escapetool.xml($jsontool.serialize($diagramConfig))"
     data-toolbar="$escapetool.xml($toolbar)"
     #if ("$!request.source" == '')


### PR DESCRIPTION
To resolve this issue properly, I had to address both the diagram macro and the normal diagram page. In the case of the diagram macro, the fix was pretty straightforward: replacing the view of the diagram from a div to the actual SVG. I had to keep the div to avoid errors in the console when exporting the PDF. To make the diagram macro work, we had to do the same thing, in addition I also had to get the right document.