### PR TITLE
 Diagram is not shown when importing from URL #320

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
@@ -795,7 +795,8 @@ define('diagram-utils', ['jquery', 'diagram-link-handler'], function($, diagramL
       let hash = url.substring(hashIndex+2);
       try {
         let decodedData = decodeURIComponent(hash);
-        // Drawio uses a combination of URL encoding and base64 encoding in the hash and this breaks the import. Since we decompress the diagram in our code when we save the page we can get rid of the
+        // Drawio uses a combination of URL encoding and base64 encoding in the hash and this breaks the import.
+        // Since we decompress the diagram in our code when we save the page we can get rid of the
         // graph.decompress method and just return the serialized DOM with the imported diagram.
         const parser = new DOMParser();
         const xmlDoc = parser.parseFromString(decodedData, "application/xml");

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
@@ -795,13 +795,10 @@ define('diagram-utils', ['jquery', 'diagram-link-handler'], function($, diagramL
       let hash = url.substring(hashIndex+2);
       try {
         let decodedData = decodeURIComponent(hash);
-        // Drawio uses a combination of URL encoding and base64 encoding in the hash and this breaks the import. For more details check https://github.com/xwikisas/application-diagram/issues/320.
+        // Drawio uses a combination of URL encoding and base64 encoding in the hash and this breaks the import. Since we decompress the diagram in our code when we save the page we can get rid of the
+        // graph.decompress method and just return the serialized DOM with the imported diagram.
         const parser = new DOMParser();
         const xmlDoc = parser.parseFromString(decodedData, "application/xml");
-        const diagramContent = xmlDoc.getElementsByTagName("diagram")[0].textContent;
-        let graph = new Graph();
-        let rawDiagramContent = graph.decompress(diagramContent);
-        diagramContent.textContent = rawDiagramContent;
         return new XMLSerializer().serializeToString(xmlDoc);
       } catch (e) {
         console.error(e.stack)

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
@@ -795,9 +795,14 @@ define('diagram-utils', ['jquery', 'diagram-link-handler'], function($, diagramL
       let hash = url.substring(hashIndex+2);
       try {
         let decodedData = decodeURIComponent(hash);
+        // Drawio uses a combination of URL encoding and base64 encoding in the hash and this breaks the import. For more details check https://github.com/xwikisas/application-diagram/issues/320.
+        const parser = new DOMParser();
+        const xmlDoc = parser.parseFromString(decodedData, "application/xml");
+        const diagramContent = xmlDoc.getElementsByTagName("diagram")[0].textContent;
         let graph = new Graph();
-        let rawDiagram = graph.decompress(decodedData);
-        return rawDiagram;
+        let rawDiagramContent = graph.decompress(diagramContent);
+        diagramContent.textContent = rawDiagramContent;
+        return new XMLSerializer().serializeToString(xmlDoc);
       } catch (e) {
         console.error(e.stack)
       }


### PR DESCRIPTION
The issue was caused by a mix of different encodings within the same text. For example, when exporting a diagram, Draw.io generates the following URL:
```
https://viewer.diagrams.net/?tags=%7B%7D&lightbox=1&highlight=0000ff&edit=_blank&layers=1&nav=1&title=TestDiagram.drawio#R%3Cmxfile%3E%3Cdiagram%20id%3D%22C5RBs43oDa-KdzZeNtuy%22%20name%3D%22Page-1%22%3E7VnbcpswEP0aT5%2FaEcgG8hg7cdLWzaRN2kwfBYhLLRAVwpd%2BfRcjDATqS1s7TiY8ZLTLenU5R7tnSA%2BPosWVIEnwibuU9XTkLnr4oqfrlnEGf3PHsnCYpl44fBG6hUurHHfhL6qcSHmz0KVpI1ByzmSYNJ0Oj2PqyIaPCMHnzTCPs%2BasCfFpy3HnENb2PoSuDNS2dLPyX9PQD8qZtXLDESGbLAAaNSRSy%2FLyuKZtRGTqkow0RFvow74UDcFPRTR6YMox9sIzKul%2BRFepvqz25A2q5%2Fa72ZOk2Ng7ansxme1rb9f6EOvqTdaj%2BZLZYcAt4F2DriK0YcRqqwrUQMrFK2VQb8HTBeT5AqI8OCCfWH8F59tRyw9qlQTzr8n90tVFW8u1yQ9uxRSj2oHcYngaBTl%2BBnO2kZ18lyGEYpr80EVKusManYcbstgqxMxGvRAjP5ItQIQZBaNW2dm5n2ERoNDqiOtG72tlR1UlZUmv0%2BEITEgIt0OSUtAmhlpd%2F8fAFcUPaANSkxKCoC1DDsajtHfFrSB8%2FtT4pK1gTUJYjpKPi5p8Goh4xQG%2B2rydaPV1ojkw8QMdUm1g7HJpgVl%2FOi2Jf%2FfsBX%2F4G%3C%2Fdiagram%3E%3C%2Fmxfile%3E

```

As we can see, the part after the #R contains the diagram, but we can see that it included two HTML tags that are URL-encoded, followed by a Base64 string. This causes an error when Draw.io attempts to call atob, as the entire string is not properly Base64-encoded, which results in a crash in the atob function and the current behavior.
Interestingly, the issue can be reproduce on the latest version of drawio.