### PR TITLE
Replace drawio PDF export with drawio File -> Print action #288

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1171,6 +1171,46 @@ define('diagram-editor', [
     }
   };
 
+
+  /*
+   * Map with all the menu items that we want to have a title.
+   */
+
+  const titleMap = new Map([
+      ['print', 'When you click this button, a popup will appear, allowing you to select which part of the diagram you want to print or export as a PDF.\
+        After clicking the "Print button, a new window will open, displaying a preview of the document. In this window, you can choose to either print the document or save it as a PDF']
+  ]);
+
+/**
+ * Modify the original method a bit to allow us to add titles to menu items.
+ */
+  Menus.prototype.addMenuItem = function(menu, key, parent, trigger, sprite, label)
+  {
+      var action = this.editorUi.actions.get(key);
+      var addTitle = titleMap.has(key);
+      if (action != null &amp;&amp; (menu.showDisabled || action.isEnabled()) &amp;&amp; action.visible)
+      {
+          var item = menu.addItem(label || action.label, null, function(evt)
+          {
+              action.funct(trigger, evt);
+          }, parent, sprite, action.isEnabled());
+          if (addTitle)
+          {
+            item.title = titleMap.get(key);
+          }
+          // Adds checkmark image
+          if (action.toggleAction &amp;&amp; action.isSelected())
+          {
+              menu.addCheckmark(item, Editor.checkmarkImage);
+          }
+
+          this.addShortcut(item, action);
+
+          return item;
+      }
+
+      return null;
+  };
   // Remove the language picker because the diagram editor is configured to use the XWiki language.
   var originalCreateMenubar = Menus.prototype.createMenubar;
   Menus.prototype.createMenubar = function(container) {
@@ -1195,7 +1235,7 @@ define('diagram-editor', [
   var renameMenu = function(editorUI) {
     const menuItems = [
       // File menu
-      ['print', 'Export PDF']
+      ['print', 'Print / Export as PDF']
     ];
 
     // Iterate over the array of tuples

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1082,9 +1082,9 @@ define('diagram-external-services', ['jquery', 'diagram-config', 'draw.io'], fun
 });
 
 define('diagramMenuTranslations', {
-  prefix: 'diagram.menu.',
+  prefix: 'diagram.editor.menu.',
   keys: [
-    //File menu
+    // File menu.
     'print.label',
     'print.title'
   ]
@@ -1196,7 +1196,7 @@ define('diagram-editor', [
   Menus.prototype.addMenuItem = function(menu, key, parent, trigger, sprite, label) {
     let item = originalAddMenuItem.apply(this, arguments);
     if (item != null &amp;&amp; titleMap.has(key)) {
-        item.title = titleMap.get(key);
+      item.title = titleMap.get(key);
     }
     return item;
   };

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1185,7 +1185,6 @@ define('diagram-editor', [
   /*
    * Map with all the menu items that we want to have a title.
    */
-
   const titleMap = new Map([
       ['print', l10n['print.title']]
   ]);

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1189,9 +1189,9 @@ define('diagram-editor', [
       ['print', l10n['print.title']]
   ]);
 
-/*
- * Update the title of the menu items.
- */
+  /*
+   * Update the title of the menu items.
+   */
   var originalAddMenuItem = Menus.prototype.addMenuItem;
   Menus.prototype.addMenuItem = function(menu, key, parent, trigger, sprite, label) {
     let item = originalAddMenuItem.apply(this, arguments);

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1081,6 +1081,15 @@ define('diagram-external-services', ['jquery', 'diagram-config', 'draw.io'], fun
   };
 });
 
+define('diagramMenuTranslations', {
+  prefix: 'diagram.menu.',
+  keys: [
+    //File menu
+    'print.label',
+    'print.title'
+  ]
+});
+
 /**
  * Integrates draw.io diagram editor in XWiki.
  */
@@ -1090,11 +1099,12 @@ define('diagram-editor', [
   'diagram-utils',
   'diagram-url-io',
   'diagram-config',
+  'xwiki-l10n!diagramMenuTranslations',
   'diagram-graph-xml-filter',
   'diagram-link-editor',
   'diagram-image-editor',
   'diagram-external-services'
-], function($, diagramStore, diagramUtils, diagramUrlIO, diagramConfig) {
+], function($, diagramStore, diagramUtils, diagramUrlIO, diagramConfig, l10n) {
 
   // These variables are used to decide if an image should be uploaded at original resolution or
   // should be declined for being too big.
@@ -1177,40 +1187,21 @@ define('diagram-editor', [
    */
 
   const titleMap = new Map([
-      ['print', 'When you click this button, a popup will appear, allowing you to select which part of the diagram you want to print or export as a PDF.\
-        After clicking the "Print button, a new window will open, displaying a preview of the document. In this window, you can choose to either print the document or save it as a PDF']
+      ['print', l10n['print.title']]
   ]);
 
-/**
- * Modify the original method a bit to allow us to add titles to menu items.
+/*
+ * Update the title of the menu items.
  */
-  Menus.prototype.addMenuItem = function(menu, key, parent, trigger, sprite, label)
-  {
-      var action = this.editorUi.actions.get(key);
-      var addTitle = titleMap.has(key);
-      if (action != null &amp;&amp; (menu.showDisabled || action.isEnabled()) &amp;&amp; action.visible)
-      {
-          var item = menu.addItem(label || action.label, null, function(evt)
-          {
-              action.funct(trigger, evt);
-          }, parent, sprite, action.isEnabled());
-          if (addTitle)
-          {
-            item.title = titleMap.get(key);
-          }
-          // Adds checkmark image
-          if (action.toggleAction &amp;&amp; action.isSelected())
-          {
-              menu.addCheckmark(item, Editor.checkmarkImage);
-          }
-
-          this.addShortcut(item, action);
-
-          return item;
-      }
-
-      return null;
+  var originalAddMenuItem = Menus.prototype.addMenuItem;
+  Menus.prototype.addMenuItem = function(menu, key, parent, trigger, sprite, label) {
+    let item = originalAddMenuItem.apply(this, arguments);
+    if (item != null &amp;&amp; titleMap.has(key)) {
+        item.title = titleMap.get(key);
+    }
+    return item;
   };
+
   // Remove the language picker because the diagram editor is configured to use the XWiki language.
   var originalCreateMenubar = Menus.prototype.createMenubar;
   Menus.prototype.createMenubar = function(container) {
@@ -1235,7 +1226,7 @@ define('diagram-editor', [
   var renameMenu = function(editorUI) {
     const menuItems = [
       // File menu
-      ['print', 'Print / Export as PDF']
+      ['print', l10n['print.label']]
     ];
 
     // Iterate over the array of tuples

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramTranslations.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramTranslations.xml
@@ -67,6 +67,10 @@ diagram.macro.invalidReference=The specified page is not a diagram.
 diagram.macro.view=View diagram
 diagram.macro.viewNotAllowed=You are not allowed to view this diagram.
 
+# Diagram menu
+diagram.menu.print.title=Print the diagram using an external device when possible, otherwise simply export and save it as PDF.
+diagram.menu.print.label=Print / Export as PDF
+
 # Diagram editor
 diagram.editor.saveAsImageAttachmentError=Error when saving the diagram as an image attachment.
 diagram.editor.disabledExternalServices=External services are disabled.

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramTranslations.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramTranslations.xml
@@ -67,13 +67,10 @@ diagram.macro.invalidReference=The specified page is not a diagram.
 diagram.macro.view=View diagram
 diagram.macro.viewNotAllowed=You are not allowed to view this diagram.
 
-# Diagram menu
-diagram.menu.print.title=Print the diagram using an external device when possible, otherwise simply export and save it as PDF.
-diagram.menu.print.label=Print / Export as PDF
-
-# Diagram editor
 diagram.editor.saveAsImageAttachmentError=Error when saving the diagram as an image attachment.
 diagram.editor.disabledExternalServices=External services are disabled.
+diagram.editor.menu.print.title=Print the diagram using an external device when possible, otherwise simply export and save it as PDF.
+diagram.editor.menu.print.label=Print / Export as PDF
 
 # Diagram Configuration
 Diagram.DiagramConfigClass_exportURL=Export URL


### PR DESCRIPTION
Renamed 'Export as PDF' to 'Print / Export as PDF' to clarify that the button has two functions. Added an additional title to help users understand how to use the button. More details are available in #321.