### PR TITLE
 Downloading SVG makes links non functional #319

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -547,6 +547,34 @@ define('diagram-link-editor', [
     // Do nothing.
   }
 
+  // Override the Graph.updateSvgLinks method to ensure that the links are preserved in the final SVG.
+  // We need to directly modify the original method because drawio does not provide a parameter to override the default behavior
+  // or a smaller method that only performs the replacement.
+  Graph.prototype.updateSvgLinks = function (node, target, removeCustom) {
+    var links = node.getElementsByTagName('a');
+    console.log(links)
+    for (var i = 0; i &lt; links.length; i++) {
+      if (links[i].getAttribute('target') == null) {
+        var href = links[i].getAttribute('href');
+        console.log(href)
+        if (href == null) {
+          href = links[i].getAttribute('xlink:href');
+        }
+
+        if (href != null) {
+          if (target != null &amp;&amp; /^https?:\/\//.test(href)) {
+            // If the href starts with http or https, set the target attribute.
+            links[i].setAttribute('target', target);
+          } else if (this.isCustomLink(href)) {
+            // Handle custom links
+            let absoluteLink = $('&lt;a/&gt;').attr('href', diagramLinkHandler.getURLFromCustomLink(href)).prop('href');
+            links[i].setAttribute('href', absoluteLink);
+          }
+        }
+      }
+    }
+  };
+
   // Overwrite Graph.getSvg in order to replace XWiki custom links with absolute URLs.
   // Also fix the text fallback for viewers with no support for foreignObjects.
   var originalGraphGetSVG = Graph.prototype.getSvg;

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -548,8 +548,8 @@ define('diagram-link-editor', [
   }
 
   // Override the Graph.updateSvgLinks method to ensure that the links are preserved in the final SVG.
-  // We need to directly modify the original method because drawio does not provide a parameter to override the default behavior
-  // or a smaller method that only performs the replacement.
+  // We need to directly modify the original method because drawio does not provide a parameter to override the default
+  // behavior or a smaller method that only performs the replacement.
   Graph.prototype.updateSvgLinks = function (node, target, removeCustom) {
     var links = node.getElementsByTagName('a');
     for (var i = 0; i &lt; links.length; i++) {

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -552,11 +552,9 @@ define('diagram-link-editor', [
   // or a smaller method that only performs the replacement.
   Graph.prototype.updateSvgLinks = function (node, target, removeCustom) {
     var links = node.getElementsByTagName('a');
-    console.log(links)
     for (var i = 0; i &lt; links.length; i++) {
       if (links[i].getAttribute('target') == null) {
         var href = links[i].getAttribute('href');
-        console.log(href)
         if (href == null) {
           href = links[i].getAttribute('xlink:href');
         }


### PR DESCRIPTION
 This issue appears to be more nuanced because there are multiple ways to add links to a page, and there are different types of links. You can add a link directly by selecting the plus button, choosing either "internal" or "external," and adding it or by highlighting text and inserting the link.

Regarding the types of links there are three categories:

1. Custom: These are internal links within XWiki.
2. External (prefixed): These links are prefixed with https://domain and work correctly, redirecting to the external site.
3. External (non-prefixed): These links lack an https:// prefix. Instead of redirecting to the external site, they redirect to localdomain/externalLink.

From my understanding, the behavior of  external (non-prefixed): is not a bug but the intended design of drawio, as it can be reproduced on https://app.diagrams.net.
To solve the issue raised by Gabrila, I can override the updateSvgLinks method in [Graph.js](https://github.com/Farcasut/drawio/blob/a2685dd63e1475fd9aea14ef52ce3f1199f38b1e/src/main/webapp/js/grapheditor/Graph.js#L12171) and retain the custom links instead of removing them.

As for the external non-prefixed links, I am unsure whether we should add the https:// part ourselves to fix and make them behave like normal external links or keep the default behavior.(oppend #330)