### PR TITLE
 Links in the diagram aren't updated when the linked pages are moved/renamed #245

### DIFF
--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/DiagramLinkHandler.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/DiagramLinkHandler.java
@@ -61,6 +61,16 @@ public class DiagramLinkHandler
     public static final String MXCELL = "mxCell";
 
     /**
+     * Link attribute.
+     */
+    public static final String LINK = "link";
+
+    /**
+     * Label attribute.
+     */
+    public static final String LABEL = "label";
+
+    /**
      * Href attribute.
      */
     private static final String HREF = "href";
@@ -119,14 +129,22 @@ public class DiagramLinkHandler
      * @param oldDocumentRef document's reference before rename
      */
     public void updateUserObjectNode(Node node, DocumentReference newDocumentRef, DocumentReference oldDocumentRef)
+        throws IOException, ParserConfigurationException, SAXException
     {
         if (node.hasChildNodes()) {
-            Node linkNode = node.getAttributes().getNamedItem("link");
-            String oldSource = linkNode.getNodeValue();
-            if (isXWikiCustomLink(oldSource)
-                && oldDocumentRef.toString().equals(getResourceReferenceFromCustomLink(oldSource))) {
-                String newSource = getCustomLinkFromResourceReference(newDocumentRef.toString());
-                linkNode.setTextContent(newSource);
+            if (node.getAttributes().getNamedItem(LINK) != null) {
+                Node linkNode = node.getAttributes().getNamedItem(LINK);
+                String oldSource = linkNode.getNodeValue();
+                if (isXWikiCustomLink(oldSource) && oldDocumentRef.toString()
+                    .equals(getResourceReferenceFromCustomLink(oldSource)))
+                {
+                    String newSource = getCustomLinkFromResourceReference(newDocumentRef.toString());
+                    linkNode.setTextContent(newSource);
+                }
+            }
+            if (node.getAttributes().getNamedItem(LABEL) != null) {
+                Node linkNode = node.getAttributes().getNamedItem(LABEL);
+                updateEmbeddedLinks(linkNode, newDocumentRef, oldDocumentRef);
             }
         }
     }
@@ -149,21 +167,32 @@ public class DiagramLinkHandler
             if (linkNode == null) {
                 return;
             }
+            updateEmbeddedLinks(linkNode, newDocumentRef, oldDocumentRef);
+        }
+    }
 
-            String value = linkNode.getNodeValue();
-            if (value.indexOf(HREF) == -1) {
-                return;
+    /**
+     * Updates the links that are embedded in node attributes.
+     * @param linkNode attribute node that contains the links
+     * @param newDocumentRef new document reference.
+     * @param oldDocumentRef old document reference.
+     */
+    private void updateEmbeddedLinks(Node linkNode, DocumentReference newDocumentRef,
+        DocumentReference oldDocumentRef) throws IOException, ParserConfigurationException, SAXException
+    {
+        String value = linkNode.getNodeValue();
+        if (value.indexOf(HREF) == -1) {
+            return;
+        }
+
+        // The value attribute contains the text element, which could contain one or more links.
+        for (String oldSource : getLinksFromEmbeddedNode(value)) {
+            if (oldSource != null && isXWikiCustomLink(oldSource) && oldDocumentRef.toString()
+                .equals(getResourceReferenceFromCustomLink(oldSource)))
+            {
+                String newSource = getCustomLinkFromResourceReference(newDocumentRef.toString());
+                linkNode.setNodeValue(value.replace(oldSource, newSource));
             }
-
-            // The value attribute contains the text element, which could contain one or more links.
-            for (String oldSource : getLinksFromEmbeddedNode(value)) {
-                if (oldSource != null && isXWikiCustomLink(oldSource)
-                    && oldDocumentRef.toString().equals(getResourceReferenceFromCustomLink(oldSource))) {
-                    String newSource = getCustomLinkFromResourceReference(newDocumentRef.toString());
-                    linkNode.setNodeValue(value.replace(oldSource, newSource));
-                }
-            }
-
         }
     }
 

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/DiagramLinkHandler.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/DiagramLinkHandler.java
@@ -132,8 +132,8 @@ public class DiagramLinkHandler
         throws IOException, ParserConfigurationException, SAXException
     {
         if (node.hasChildNodes()) {
-            if (node.getAttributes().getNamedItem(LINK) != null) {
-                Node linkNode = node.getAttributes().getNamedItem(LINK);
+            Node linkNode = node.getAttributes().getNamedItem(LINK);
+            if (linkNode != null) {
                 String oldSource = linkNode.getNodeValue();
                 if (isXWikiCustomLink(oldSource) && oldDocumentRef.toString()
                     .equals(getResourceReferenceFromCustomLink(oldSource)))
@@ -142,8 +142,8 @@ public class DiagramLinkHandler
                     linkNode.setTextContent(newSource);
                 }
             }
-            if (node.getAttributes().getNamedItem(LABEL) != null) {
-                Node linkNode = node.getAttributes().getNamedItem(LABEL);
+            linkNode = node.getAttributes().getNamedItem(LABEL);
+            if (linkNode != null) {
                 updateEmbeddedLinks(linkNode, newDocumentRef, oldDocumentRef);
             }
         }

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/GetDiagramLinksHandler.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/GetDiagramLinksHandler.java
@@ -70,8 +70,8 @@ public class GetDiagramLinksHandler extends DefaultHandler
             if (attributes.getValue(LINK) != null) {
                 linkedPages.add(linkHandler.getUserObjectNodeLink(attributes.getValue(LINK)));
             }
-            // I didn't manage to create the situation where the are links in both the LINK and LABEL attributes, but to
-            // keep it safe we check both cases instead of having an else if.
+            // I didn't manage to create the situation where there are links in both the LINK and LABEL attributes,
+            // but to keep it safe we check both cases instead of having an else if.
             if (attributes.getValue(LABEL) != null && attributes.getValue(LABEL).contains("href")) {
                 linkedPages.addAll(linkHandler.getMxCellNodeLinks(attributes.getValue(LABEL)));
             }

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/GetDiagramLinksHandler.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/handlers/GetDiagramLinksHandler.java
@@ -45,6 +45,10 @@ import org.xwiki.model.reference.DocumentReferenceResolver;
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 public class GetDiagramLinksHandler extends DefaultHandler
 {
+    private static final String LINK = "link";
+
+    private static final String LABEL = "label";
+
     @Inject
     private DiagramLinkHandler linkHandler;
 
@@ -61,7 +65,16 @@ public class GetDiagramLinksHandler extends DefaultHandler
     public void startElement(String uri, String key, String qName, Attributes attributes) throws SAXException
     {
         if (qName.equalsIgnoreCase(DiagramLinkHandler.USEROBJECT)) {
-            linkedPages.add(linkHandler.getUserObjectNodeLink(attributes.getValue("link")));
+            // User Object nodes can store the link in 2 places in the attribute "link" and in the label as
+            // a <a href = "customLink">actualLabel</a>
+            if (attributes.getValue(LINK) != null) {
+                linkedPages.add(linkHandler.getUserObjectNodeLink(attributes.getValue(LINK)));
+            }
+            // I didn't manage to create the situation where the are links in both the LINK and LABEL attributes, but to
+            // keep it safe we check both cases instead of having an else if.
+            if (attributes.getValue(LABEL) != null && attributes.getValue(LABEL).contains("href")) {
+                linkedPages.addAll(linkHandler.getMxCellNodeLinks(attributes.getValue(LABEL)));
+            }
         } else if (qName.equalsIgnoreCase(DiagramLinkHandler.MXCELL)) {
             linkedPages.addAll(linkHandler.getMxCellNodeLinks(attributes.getValue("value")));
         }


### PR DESCRIPTION
This issue occurred because Draw.io has multiple ways of storing links, and our code didn't check for a specific case. To fix it, I updated the methods that retrieve&updates the links from the diagram.

https://github.com/user-attachments/assets/ba0d74b5-ae3d-4e70-bf7c-dfd97ce849ec

