### PR TITLE
Diagram links not showing until page is refreshed, after editing a page with a diagram macro #269

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
@@ -125,15 +125,13 @@
       <cache>long</cache>
     </property>
     <property>
-      <code>require(['jquery'], function($){
-  $(document).on('xwiki:actions:view', function(){
-    require(['diagram-setup'], function() {
-      require(['diagram-viewer'], function(diagramViewerPromise) {
-        $('.diagram').viewDiagram();
-      });
+      <code>require(['jquery'], function($) {
+  $(document).on('xwiki:actions:view', function() {
+    require(['diagram-setup', 'diagram-viewer'], function(diagramSetup, diagramViewerPromise) {
+      $('.diagram').viewDiagram();
     });
-  })
-})</code>
+  });
+});</code>
     </property>
     <property>
       <name/>

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
@@ -128,10 +128,8 @@
       <code>require(['jquery'], function($){
   $(document).on('xwiki:actions:view', function(){
     require(['diagram-setup'], function() {
-      require(['jquery', 'diagram-viewer'], function($, diagramViewerPromise) {
-        diagramViewerPromise.done(function() {
-          $('.diagram').viewDiagram();
-        });
+      require(['diagram-viewer'], function(diagramViewerPromise) {
+        $('.diagram').viewDiagram();
       });
     });
   })

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
@@ -40,6 +40,116 @@
   <object>
     <name>Diagram.DiagramMacro</name>
     <number>0</number>
+    <className>XWiki.JavaScriptExtension</className>
+    <guid>aff1e947-48aa-4167-b0bf-68bc4d3a09ba</guid>
+    <class>
+      <name>XWiki.JavaScriptExtension</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <cache>
+        <cache>0</cache>
+        <defaultValue>long</defaultValue>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>cache</name>
+        <number>5</number>
+        <prettyName>Caching policy</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>long|short|default|forbid</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </cache>
+      <code>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>code</name>
+        <number>2</number>
+        <prettyName>Code</prettyName>
+        <restricted>0</restricted>
+        <rows>20</rows>
+        <size>50</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parse>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>parse</name>
+        <number>4</number>
+        <prettyName>Parse content</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </parse>
+      <use>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>use</name>
+        <number>3</number>
+        <prettyName>Use this extension</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>currentPage|onDemand|always</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </use>
+    </class>
+    <property>
+      <cache>long</cache>
+    </property>
+    <property>
+      <code>require(['jquery'], function($){
+  $(document).on('xwiki:actions:view', function(){
+    require(['diagram-setup'], function() {
+      require(['jquery', 'diagram-viewer'], function($, diagramViewerPromise) {
+        diagramViewerPromise.done(function() {
+          $('.diagram').viewDiagram();
+        });
+      });
+    });
+  })
+})</code>
+    </property>
+    <property>
+      <name/>
+    </property>
+    <property>
+      <parse>0</parse>
+    </property>
+    <property>
+      <use>onDemand</use>
+    </property>
+  </object>
+  <object>
+    <name>Diagram.DiagramMacro</name>
+    <number>0</number>
     <className>XWiki.WikiMacroClass</className>
     <guid>eeea7d53-d3c0-4102-a27f-9d7b54aaeaa1</guid>
     <class>
@@ -352,6 +462,7 @@
 #end
 
 #macro (executeDiagramMacro)
+  #set ($discard = $xwiki.jsx.use('Diagram.DiagramMacro'))
   #set ($reference = $xcontext.macro.params.reference)
   #if ($stringtool.isEmpty($reference))
     #set ($reference = $services.model.createDocumentReference('Diagram', $doc.documentReference.parent))

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -52,7 +52,7 @@
     #set ($displayDiv  =  'hidden')
     &lt;div&gt;
       $doc.getAttachment('diagram.svg').getContentAsString()
-    &lt;div&gt;
+    &lt;/div&gt;
   #end
   &lt;div class="diagram $displayDiv"
     data-diagram-config="$escapetool.xml($jsontool.serialize($diagramConfig))"


### PR DESCRIPTION
Updated the code to re-execute the loading of the diagram "viewer" when exiting inline edit mode.