### PR TITLE
Export as "URL...." isn't working and gives "Unknown error" #337

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -554,6 +554,7 @@ define('diagram-link-editor', [
   'draw.io',
   'resourceSelector'
 ], function($, diagramLinkHandler) {
+    window.mxIsElectron = false;
   /**
    * Override in order to change the Element type check from a.constructor !== Element, which was failing due to a
    * collision with the PrototypeJS's own implementation of the standard Element.

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -554,7 +554,6 @@ define('diagram-link-editor', [
   'draw.io',
   'resourceSelector'
 ], function($, diagramLinkHandler) {
-    window.mxIsElectron = false;
   /**
    * Override in order to change the Element type check from a.constructor !== Element, which was failing due to a
    * collision with the PrototypeJS's own implementation of the standard Element.

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
@@ -245,6 +245,7 @@ define('diagram-config', ['jquery'], function($) {
  * Diagram application setup.
  */
 define('diagram-setup', ['diagram-config'], function(diagramConfig) {
+  window.mxIsElectron = false;
   var drawIOBasePath = diagramConfig.drawIOBasePath;
   // mxGraph client setup
   window.mxBasePath = drawIOBasePath + 'mxgraph';


### PR DESCRIPTION
* The URL export is failing because mxIsElectron is no longer defined. I manually set it to always be false since XWiki is a web app, and Electron is for desktop applications.