### PR TITLE
Background "Change..." UI isn't aligned properly #336

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -572,7 +572,7 @@ define('diagram-link-editor', [
         var change = new ChangePageSetup(this, (showColor) ? color : null, image);
         change.ignoreColor = !showColor;
 
-        if (shadowVisible != null & amp;& amp; showColor) {
+        if (shadowVisible != null &amp;&amp; showColor) {
       change.shadowVisible = shadowVisible;
     }
 

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -565,6 +565,27 @@ define('diagram-link-editor', [
       a.nodeName.toLowerCase() != b.toLowerCase() ? !1 : null == c || a.getAttribute(c) == d;
   };
 
+  var originalShowBackgroundImageDialog = EditorUi.prototype.showBackgroundImageDialog
+  EditorUi.prototype.showBackgroundImageDialog = function (apply, img, color, showColor) {
+    apply = (apply != null) ? apply : mxUtils.bind(this, function (image, failed, color, shadowVisible) {
+      if (!failed) {
+        var change = new ChangePageSetup(this, (showColor) ? color : null, image);
+        change.ignoreColor = !showColor;
+
+        if (shadowVisible != null & amp;& amp; showColor) {
+      change.shadowVisible = shadowVisible;
+    }
+
+    this.editor.graph.model.execute(change);
+  }
+    });
+
+  var dlg = new BackgroundImageDialog(this, apply, img, color, showColor);
+  this.showDialog(dlg.container, 420, (showColor) ? 260 : 240, true, true);
+  dlg.init();
+  };
+
+
   EditorUi.prototype.showLinkDialog = function(value, selectLabel, callback, showNewWindowOption, linkTarget) {
     var resourceReference = diagramLinkHandler.getResourceReferenceFromCustomLink(value);
     // We append the modal to the body element in order to fix Issue #108: "Inserting a link in full screen mode is not

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -565,25 +565,27 @@ define('diagram-link-editor', [
       a.nodeName.toLowerCase() != b.toLowerCase() ? !1 : null == c || a.getAttribute(c) == d;
   };
 
-  var originalShowBackgroundImageDialog = EditorUi.prototype.showBackgroundImageDialog
-  EditorUi.prototype.showBackgroundImageDialog = function (apply, img, color, showColor) {
-    apply = (apply != null) ? apply : mxUtils.bind(this, function (image, failed, color, shadowVisible) {
-      if (!failed) {
-        var change = new ChangePageSetup(this, (showColor) ? color : null, image);
-        change.ignoreColor = !showColor;
-
-        if (shadowVisible != null &amp;&amp; showColor) {
-      change.shadowVisible = shadowVisible;
+/**
+ * TODO: When upgrading, make sure to check if this method has changed.
+ * This method was copied directly from draw.io, and the only change made was the call to this.showDialog.
+ * Both the width and height were modified to fit better within the XWiki UI.
+ */
+EditorUi.prototype.showBackgroundImageDialog = function (apply, img, color, showColor) {
+  apply = (apply != null) ? apply : mxUtils.bind(this, function (image, failed, color, shadowVisible) {
+    if (!failed) {
+      var change = new ChangePageSetup(this, (showColor) ? color : null, image);
+      change.ignoreColor = !showColor;
+      if (shadowVisible != null &amp;&amp;  showColor) {
+        change.shadowVisible = shadowVisible;
+      }
+      this.editor.graph.model.execute(change);
     }
-
-    this.editor.graph.model.execute(change);
-  }
-    });
+  });
 
   var dlg = new BackgroundImageDialog(this, apply, img, color, showColor);
   this.showDialog(dlg.container, 420, (showColor) ? 260 : 240, true, true);
   dlg.init();
-  };
+};
 
 
   EditorUi.prototype.showLinkDialog = function(value, selectLabel, callback, showNewWindowOption, linkTarget) {

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramSheet.xml
@@ -1152,7 +1152,11 @@ Right now, there is no defined LESS value for the background color. If, in the f
 .geSidebarContainer {
   user-select: none;
 }
-</code>
+
+/* Properly align the radio buttons in the change background popup. */
+input[name="geBackgroundImageDialogOption"] {
+  margin-bottom: 0px !important;
+}</code>
     </property>
     <property>
       <contentType>CSS</contentType>


### PR DESCRIPTION
* The issue was caused by the popup size. I updated the size to be slightly larger to work better with the xwiki ui. However, I couldn't achieve this fully through CSS because drawio has one big class for all the popups adjusts the size through the dialog class, so I had to overwrite the showBackgroundImageDialog
![image](https://github.com/user-attachments/assets/9a9225fd-6e96-483a-a83e-809d49a93f70)


