### PR TITLE
Diagram attachments are not generated #366

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -360,7 +360,7 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
   };
 
   var deleteAllDiagrams = function() {
-    let baseUrl = `/xwiki/rest/diagram/${xm.documentReference.toString()}`;
+    let baseUrl = `${XWiki.contextPath}/rest/diagram/${xm.documentReference.toString()}`;
     let queryString = $.param({"form_token": xm.form_token});
     return $.post(`${baseUrl}?${queryString}`);
   };


### PR DESCRIPTION
The issue only occurred inside docker containers because they were installed in the root context. In this setup, the rest api root was slightly different, rather than /xwiki/rest, it was just /rest/ and because of this the diagram endpoint wasn't found.