### PR TITLE
For 'mailto:' links 'https://' is automatically added #376

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/ResourceSelector/WebHome.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/ResourceSelector/WebHome.xml
@@ -212,7 +212,7 @@
         if (entry.name === 'resourceType') {
           selectedResource.type = entry.value;
         } else if (entry.name === 'resourceReference') {
-           selectedResource.reference = entry.type == 'external' &amp;&amp; !entry.value.includes('://') ?
+           selectedResource.reference = entry.type == 'external' &amp;&amp; !entry.value.includes(':') ?
         `https://${entry.value}` : entry.value;
         }
       }


### PR DESCRIPTION
My idea was to check for a ':' to see if a protocol is already there, since ':' is supposed to be reserved according to the [RFC](https://datatracker.ietf.org/doc/html/rfc3986#section-1.3), but I'm not 100% that everyone is respecting the RFC