### PR TITLE
Error message displayed on Chrome and Edge when displaying a diagram from an external URL #384

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -330,7 +330,7 @@ define('diagram-viewer', [
         diagramXML = window.externalDiagramUrlCache.get(externalDiagramUrl);
         if (!diagramXML) {
           // Use a proxy to get around CORS.
-          diagramXML = mxUtils.load(getProxyUrl(externalDiagramUrl)).getXml().activeElement;
+          diagramXML = mxUtils.load(getProxyUrl(externalDiagramUrl)).getXml().documentElement;
           window.externalDiagramUrlCache.set(externalDiagramUrl, diagramXML);
         }
         // Add the XML so drawio can access it.


### PR DESCRIPTION
In firefox, the `.activeElement` property returns the element, which is a bit of a weird case according to [the reference (second point)](https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement#value). The element is not a child of the DOM, so the active element should be null (which is the case for other browsers).

Active element is linked to keyboard events, but in this case we only need an `Element` object. For this, the `documentElement` will suffice