### PR TITLE
Background image not saved when adding image URL #383

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramProxy.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramProxy.xml
@@ -49,9 +49,9 @@ if (url &amp;&amp; xcontext.getUserReference()) {
         connection.setRequestProperty('User-Agent', "XWiki's Diagram Application");
         response.setStatus(connection.getResponseCode());
         response.setContentType(connection.getContentType());
-        def data = new String(connection.getInputStream().readAllBytes());
+        def data = connection.getInputStream().readAllBytes();
         if (importDiagramParam) {
-          def convertedData = new DiagramImporter().importDiagram(data, url);
+          def convertedData = new DiagramImporter().importDiagram(new String(data), url);
           data = convertedData ? convertedData : data;
         }
         response.getOutputStream() &lt;&lt; data;


### PR DESCRIPTION
Changed the `DiagramProxy` to not convert the data to a String when it's not needed (which can break image encodings).

Edit: While testing I came across extreme slowness and eventually `OutOfMemoryException` when saving and viewing the diagram with background image multiple times (especially when viewing the attachments tab), but it affects version `1.22.6` of Diagram Pro too. Related to #183 I think.