### PR TITLE
Background color of diagrams is not visible in view mode on Cloud #379

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -377,11 +377,13 @@ define('diagram-viewer', [
     $(element).children().text(text);
   };
 
+  const initializedDiagramMarkerClass = 'diagram-initialized';
   $.fn.viewDiagram = function(configOverride) {
     return this.each(function() {
       try {
         // Guard against re-rendering an existing diagram or one which is in the process of displaying.
-        if (this.childElementCount == 1) {
+        if (!this.classList.contains(initializedDiagramMarkerClass)) {
+          this.classList.add(initializedDiagramMarkerClass);
           let [fromStorage, diagramXML] = getDiagramXML(this);
           renderDiagram(this, diagramXML, fromStorage, configOverride);
         }


### PR DESCRIPTION
There was an added check to skip initialization of diagrams to not overwrite existing diagrams, but it was active in more cases than was intended. This led to loading the svg attachment instead, which doesn't have the background color included (due to other issues, like #242 ).

Now the initializing diagrams should be clearer and more intentional.