### PR TITLE
Allow displaying a diagram from an external URL #369

### DIFF
--- a/application-diagram-api/pom.xml
+++ b/application-diagram-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.xwiki.diagram</groupId>
     <artifactId>application-diagram-parent</artifactId>
-    <version>1.22.7-369-SNAPSHOT-2-SNAPSHOT</version>
+    <version>1.22.7-SNAPSHOT</version>
   </parent>
   <artifactId>application-diagram-api</artifactId>
   <name>Diagram Application (Pro) - API</name>

--- a/application-diagram-export/pom.xml
+++ b/application-diagram-export/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.xwiki.diagram</groupId>
     <artifactId>application-diagram-parent</artifactId>
-    <version>1.22.7-369-SNAPSHOT-2-SNAPSHOT</version>
+    <version>1.22.7-SNAPSHOT</version>
   </parent>
   <artifactId>application-diagram-export</artifactId>
   <name>Diagram Application (Pro) - Export API</name>

--- a/application-diagram-ui/pom.xml
+++ b/application-diagram-ui/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.xwiki.diagram</groupId>
     <artifactId>application-diagram-parent</artifactId>
-    <version>1.22.7-369-SNAPSHOT-2-SNAPSHOT</version>
+    <version>1.22.7-SNAPSHOT</version>
   </parent>
   <artifactId>application-diagram</artifactId>
   <name>Diagram Application (Pro) - UI</name>

--- a/application-diagram-xip/pom.xml
+++ b/application-diagram-xip/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.xwiki.diagram</groupId>
     <artifactId>application-diagram-parent</artifactId>
-    <version>1.22.7-369-SNAPSHOT-2-SNAPSHOT</version>
+    <version>1.22.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>application-diagram-xip</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   </parent>
   <groupId>com.xwiki.diagram</groupId>
   <artifactId>application-diagram-parent</artifactId>
-  <version>1.22.7-369-SNAPSHOT-2-SNAPSHOT</version>
+  <version>1.22.7-SNAPSHOT</version>
   <name>Diagram Application (Pro) - Parent POM</name>
   <packaging>pom</packaging>
   <description>Create easy to use diagrams and flowcharts using draw.io. Import Gliffy diagrams. Include diagrams in other pages. Export them as PDFs or images. The app can be purchased individually or part of the XWiki Pro package. Try it free.</description>


### PR DESCRIPTION
* Added new parameter to fetch the diagram from an external source
  * The resulting diagram is read-only
  * The url is expected to return an xml file in the drawio format
* The external source is only used in view mode and in-line edit mode, for non-guests

<img width="1060" height="750" alt="image" src="https://github.com/user-attachments/assets/06ced1de-66c6-4087-b569-60d46218b5c9" />
