### PR TITLE
Reference not updated after renaming the linked diagram page on XWiki 16.x

### DIFF
--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramMacroRunnable.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramMacroRunnable.java
@@ -42,7 +42,7 @@ import com.xpn.xwiki.doc.XWikiDocument;
 
 /**
  * Updates diagram macro reference parameter after the rename of a diagram.
- * 
+ *
  * @version $Id$
  * @since 1.13.1
  */
@@ -60,6 +60,7 @@ public class DiagramMacroRunnable extends AbstractDiagramRunnable
     private EntityReferenceSerializer<String> compactEntityReferenceSerializer;
 
     @Inject
+    @Named("explicit")
     private DocumentReferenceResolver<String> resolver;
 
     @Inject
@@ -101,7 +102,7 @@ public class DiagramMacroRunnable extends AbstractDiagramRunnable
 
     /**
      * Update for a page diagram macros old references with new ones.
-     * 
+     *
      * @param document document that need to be updated with the new reference
      * @param newReference new diagram reference
      * @param oldReference old diagram reference of a macro
@@ -122,8 +123,8 @@ public class DiagramMacroRunnable extends AbstractDiagramRunnable
         Boolean modified = false;
         for (Block macroBlock : macroBlocks) {
             String rawReference = macroBlock.getParameter(MACRO_REFERENCE_PARAMETER);
-            String macroReference = compactEntityReferenceSerializer.serialize(resolver.resolve(rawReference),
-                document.getDocumentReference());
+            String macroReference = compactEntityReferenceSerializer.serialize(resolver.resolve(rawReference,
+                document.getDocumentReference()), document.getDocumentReference());
 
             if (!macroReference.equals(newReferenceString) && macroReference.equals(oldReferenceString)) {
                 macroBlock.setParameter(MACRO_REFERENCE_PARAMETER, newReferenceString);


### PR DESCRIPTION
The issue was caused by a mismatch between how the diagram was storing the reference and how it was using it. Specifically, the diagram was storing the reference as either relative or absolute, but when attempting to rename, it was comparing the exact reference used in the macro with references retrieved using the compact serializer. This led to comparing absolute references versus relative ones at times. In addition, I also added an explicit default value to the reference instead of the current implicit one, as the implicit value was interfering with backlinks and sometimes preventing them from being created. I have run quick tests on an instance(I also tried the unique ns) and everything was okay.
