### PR TITLE
Diagrams with "." in their title get saved without any image/diagram inside them #393

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -360,7 +360,7 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
   };
 
   var deleteAllDiagrams = function() {
-    let baseUrl = `${XWiki.contextPath}/rest/diagram/${xm.documentReference.toString()}`;
+    let baseUrl = `${XWiki.contextPath}/rest/diagram/${encodeURIComponent(xm.documentReference.toString())}`;
     let queryString = $.param({"form_token": xm.form_token});
     return $.post(`${baseUrl}?${queryString}`);
   };


### PR DESCRIPTION
Depending on the naming strategy, the . in the reference is replaced with either / or -. When it is replaced with /, the POST fails because the request is sent to the wrong path.