### PR TITLE
Diagram macro does not display Diagrams with specific characters in the name #397

### DIFF
--- a/application-diagram-api/src/main/java/com/xwiki/diagram/DiagramResources.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/DiagramResources.java
@@ -22,7 +22,6 @@ package com.xwiki.diagram;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
@@ -44,19 +43,7 @@ public interface DiagramResources extends XWikiRestComponent
      * errors.
      */
     @POST
-    @Path("{documentReference}")
-    Response deleteAttachments(
-        @PathParam("documentReference") @Encoded String documentReference) throws Exception;
-
-    /**
-     * Deletes the attachments associated with a diagram.
-     *
-     * @param documentReference
-     * @return OK if the deletion was successfully finished, 405 if the user doesn't have rights or 500 for other
-     * errors.
-     */
-    @POST
     @Path("deleteDiagramAttachments")
-    Response deleteDiagramAttachments(
+    Response deleteAttachments(
         @QueryParam("documentReference") @Encoded String documentReference) throws Exception;
 }

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/rest/DiagramResourcesImpl.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/rest/DiagramResourcesImpl.java
@@ -72,12 +72,6 @@ public class DiagramResourcesImpl extends XWikiResource implements DiagramResour
     @Override
     public Response deleteAttachments(String documentReference) throws Exception
     {
-        return deleteDiagramAttachments(documentReference);
-    }
-
-    @Override
-    public Response deleteDiagramAttachments(String documentReference) throws Exception
-    {
 
         XWikiContext context = contextProvider.get();
         XWiki xwiki = context.getWiki();

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -368,8 +368,7 @@ define('diagram-store', ['jquery', 'xwiki-meta', 'xwiki-utils', 'diagram-utils',
   };
 
   var deleteAllDiagrams = function() {
-    let baseUrl =
-      `${XWiki.contextPath}/rest/diagram/deleteDiagramAttachments`;
+    let baseUrl = `${XWiki.contextPath}/rest/diagram/deleteDiagramAttachments`;
     let queryString = $.param({
       "form_token": xm.form_token,
       "documentReference": encodeURIComponent(xm.documentReference.toString())


### PR DESCRIPTION
* Added new rest endpoint to get around URL character restriction
* Added some translations

If the fix is not visible at first, you may need to press `ctrl+f5` on the diagram edit page a few times to refresh the cache.