### PR TITLE
Diagram top bar leaves the screen #371

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -276,6 +276,30 @@ define('diagram-viewer', [
     return config;
   };
 
+  const observer = new MutationObserver((mutations) =&gt; {
+    mutations.forEach((mutation) =&gt; {
+      mutation.addedNodes.forEach((node) =&gt; {
+        if ($(node).hasClass('xwiki-diagram-drawio-toolbar')) {
+          node.style.width = Math.min($('#xwikicontent').width(), parseInt(node.style.width)) + 'px';
+        }
+      });
+      if (mutation.type === 'attributes') {
+        if ($(mutation.target).hasClass('xwiki-diagram-drawio-toolbar')) {
+          mutation.target.style.width =
+            Math.min($('#xwikicontent').width(), parseInt(mutation.target.style.width)) + 'px';
+        }
+      }
+    });
+  });
+
+  // Enforce the maximum width of the diagram toolbar to prevent overflows.
+  observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['style']
+  });
+
   // Fix position of a dialog at the top of the window.
   Dialog.prototype.fixDialogPosition = function() {
     this.container.style.top = '0px';
@@ -362,6 +386,8 @@ define('diagram-viewer', [
       var diagramLink = $('&lt;a/&gt;').attr('href', diagramViewURL).text(config.title);
       $(graphViewer.toolbar).children().last().empty().append(diagramLink);
     }
+    // Identify the toolbar by class.
+    $(graphViewer.toolbar).addClass('xwiki-diagram-drawio-toolbar');
   }
 
   function getErrorKey(externalDiagramUrl, hasUser) {


### PR DESCRIPTION
* Added DOM listener to limit the max width of the toolbar

Old behavior:

[![Old behavior](https://github.com/user-attachments/assets/aad93a96-3811-424a-8953-3d4368b3b245)](https://github.com/user-attachments/assets/7aa20b76-49df-4e4f-a2e2-a11f8205820c)

New behavior:

[![New behavior](https://github.com/user-attachments/assets/aad93a96-3811-424a-8953-3d4368b3b245)](https://github.com/user-attachments/assets/6faa4010-2083-4d25-9ae9-72069035f112)
