### PR TITLE
Keyboard Shortcuts Help section is inaccessible #360

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -878,7 +878,7 @@ define('diagram-editor', [
   'diagram-image-editor',
   'diagram-external-services'
 ], function($, diagramStore, diagramUtils, diagramUrlIO, diagramConfig, l10n) {
-  var diagramEditorBasePath = "$services.webjars.url('org.xwiki.contrib:draw.io', '')";
+  var diagramEditorKeyboardShortcutsPath = "$services.webjars.url('org.xwiki.contrib:draw.io', 'shortcuts.svg')";
   // These variables are used to decide if an image should be uploaded at original resolution or
   // should be declined for being too big.
   // Default values:
@@ -1075,7 +1075,7 @@ define('diagram-editor', [
       var originalFunct = keyboardShortcutsAction.funct;
       keyboardShortcutsAction.funct = function() {
         if (mxClient.IS_SVG) {
-          window.open(diagramEditorBasePath + 'shortcuts.svg');
+          window.open(diagramEditorKeyboardShortcutsPath);
         } else {
           originalFunct.apply(this, arguments);
         }


### PR DESCRIPTION
* Add missing variable

The `Keyboard Shortcuts` button now opens a new tab with the following resource:
http://localhost:8080/xwiki/webjars/wiki%3Axwiki/draw.io/24.5.5-3/shortcuts.svg
<img width="1861" height="864" alt="image" src="https://github.com/user-attachments/assets/77e4c8c6-e313-4ada-bbd5-62a2b22cb79d" />
