### PR TITLE
Fullscreen button not working properly #411

### DIFF
--- a/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -1098,8 +1098,8 @@ define('diagram-editor', [
   };
 
   var fullScreen = new XWiki.widgets.FullScreen();
-  // We only call  the init in versions that have the function defined so we don't get an error in the console. The if should be removed after upgrading the app
-  // to a parent &gt;= 17.10.2
+  // We only call  the init in versions that have the function defined so we don't get an error in the console.
+  // The 'if' should be removed after upgrading the app to a parent &gt;= 17.10.2.
   if (typeof fullScreen.initDom === 'function') {
     fullScreen.initDom();
   }


### PR DESCRIPTION
The issue was caused by this [PR](https://github.com/xwiki/xwiki-platform/commit/9798e5a88a30944d3b70fedc502d7e44222da6fa) from the platform that updated how the FullScreen widget is working.