### PR TITLE
Upgrade Parent to 15.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This application integrates [jgraph/draw.io](https://github.com/jgraph/draw.io/)
 * Project Lead: [Oana-Lavinia Florean](https://github.com/oanalavinia)
 * [Documentation](https://store.xwiki.com/xwiki/bin/view/Extension/DiagramApplication)
 * [Development Practices](http://dev.xwiki.org)
-* Minimal XWiki version supported: XWiki 14.10
+* Minimal XWiki version supported: XWiki 15.10
 * License: LGPL 2.1+ for the application code. Note that the draw.io code the application depends on is licensed under Apache 2.0 license.
 * Translations: N/A
 * Sonar Dashboard: N/A

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramApplicationListener.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/DiagramApplicationListener.java
@@ -56,7 +56,7 @@ public class DiagramApplicationListener extends AbstractEventListener implements
 {
     protected static final String ROLE_HINT = "DiagramApplicationListener";
 
-    private static final String DIAGRAM_APPPLICATION_ID = "com.xwiki.diagram:application-diagram";
+    private static final String DIAGRAM_APPLICATION_ID = "com.xwiki.diagram:application-diagram";
 
     @Inject
     private Logger logger;
@@ -81,11 +81,8 @@ public class DiagramApplicationListener extends AbstractEventListener implements
      */
     public DiagramApplicationListener()
     {
-        // TODO: Filter also ExtensionInstalledEvent by diagram extension id after XCOMMONS-2526: Provide constructors
-        //  for ExtensionInstalledEvent that does not take namespace is fixed and diagram starts depending on a
-        //  version of XWiki >= the version where is fixed.
         super(ROLE_HINT,
-            Arrays.<Event>asList(new ExtensionUpgradedEvent(DIAGRAM_APPPLICATION_ID), new ExtensionInstalledEvent()));
+            Arrays.<Event>asList(new ExtensionUpgradedEvent(DIAGRAM_APPLICATION_ID), new ExtensionInstalledEvent()));
     }
 
     /**
@@ -117,7 +114,7 @@ public class DiagramApplicationListener extends AbstractEventListener implements
 
     private static boolean isDiagramInstallEvent(Event event)
     {
-        return event instanceof ExtensionInstalledEvent && DIAGRAM_APPPLICATION_ID.equals(
+        return event instanceof ExtensionInstalledEvent && DIAGRAM_APPLICATION_ID.equals(
             ((ExtensionEvent) event).getExtensionId().getId());
     }
 

--- a/application-diagram-api/src/main/java/com/xwiki/diagram/internal/StoreSVGAsAttachmentMigration.java
+++ b/application-diagram-api/src/main/java/com/xwiki/diagram/internal/StoreSVGAsAttachmentMigration.java
@@ -20,6 +20,7 @@
 package com.xwiki.diagram.internal;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -80,7 +81,8 @@ public class StoreSVGAsAttachmentMigration extends AbstractDiagramMigration
                 BaseObject diagramObject = document.getXObject(DIAGRAM_CLASS_REFERENCE);
                 if (diagramObject != null) {
                     String svg = diagramObject.getLargeStringValue("svg");
-                    document.addAttachment(DIAGRAM_ATTACHMENT_NAME, new ByteArrayInputStream(svg.getBytes("UTF-8")),
+                    document.setAttachment(DIAGRAM_ATTACHMENT_NAME, new ByteArrayInputStream(svg.getBytes(
+                            StandardCharsets.UTF_8)),
                         xcontext);
                     synchronizeObject(diagramObject, xcontext);
                     // Preserve the diagram author.
@@ -98,7 +100,7 @@ public class StoreSVGAsAttachmentMigration extends AbstractDiagramMigration
      * Remove deprecated fields (properties deleted from the XClass) from an object.
      *
      * @param object the object to synchronize
-     * @param context the current request context
+     * @param xcontext the current request context
      */
     private void synchronizeObject(BaseObject object, XWikiContext xcontext)
     {

--- a/application-diagram-test/application-diagram-test-docker/pom.xml
+++ b/application-diagram-test/application-diagram-test-docker/pom.xml
@@ -53,6 +53,11 @@
     </dependency>
     <!-- Test dependencies -->
     <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-logging-api</artifactId>
+      <version>${commons.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-test-docker</artifactId>
       <version>${platform.version}</version>

--- a/application-diagram-test/application-diagram-test-docker/src/test/it/com/xwiki/diagram/test/ui/AllIT.java
+++ b/application-diagram-test/application-diagram-test-docker/src/test/it/com/xwiki/diagram/test/ui/AllIT.java
@@ -31,7 +31,7 @@ import org.xwiki.test.docker.junit5.UITest;
  * @since 1.22.8
  */
 @UITest
-public class AllITs
+public class AllIT
 {
     @Nested
     @DisplayName("Diagram Tests")

--- a/application-diagram-ui/src/main/resources/Diagram/CommonCode.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/CommonCode.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.6" reference="Diagram.CommonCode" locale="">
+<xwikidoc version="1.5" reference="Diagram.CommonCode" locale="">
   <web>Diagram</web>
   <name>CommonCode</name>
   <language/>

--- a/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml
@@ -183,7 +183,7 @@
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|doc.revision|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.session|request.url=Request URL|request.wiki=Request wiki|sheet|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>
@@ -539,9 +539,6 @@
       <defaultCategories/>
     </property>
     <property>
-      <defaultCategory>Content</defaultCategory>
-    </property>
-    <property>
       <description>Displays a diagram.</description>
     </property>
     <property>
@@ -614,13 +611,24 @@
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
       <type>
+        <cache>0</cache>
+        <defaultValue>Unknown</defaultValue>
         <disabled>0</disabled>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <largeStorage>1</largeStorage>
+        <multiSelect>0</multiSelect>
         <name>type</name>
         <number>5</number>
+        <picker>1</picker>
         <prettyName>Parameter type</prettyName>
-        <size>60</size>
+        <relationalStorage>0</relationalStorage>
+        <separator>|</separator>
+        <separators>|</separators>
+        <size>1</size>
         <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <values>Unknown|Wiki</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </type>
     </class>
     <property>
@@ -693,13 +701,24 @@
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
       <type>
+        <cache>0</cache>
+        <defaultValue>Unknown</defaultValue>
         <disabled>0</disabled>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <largeStorage>1</largeStorage>
+        <multiSelect>0</multiSelect>
         <name>type</name>
         <number>5</number>
+        <picker>1</picker>
         <prettyName>Parameter type</prettyName>
-        <size>60</size>
+        <relationalStorage>0</relationalStorage>
+        <separator>|</separator>
+        <separators>|</separators>
+        <size>1</size>
         <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <values>Unknown|Wiki</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </type>
     </class>
     <property>
@@ -772,13 +791,24 @@
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
       <type>
+        <cache>0</cache>
+        <defaultValue>Unknown</defaultValue>
         <disabled>0</disabled>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <largeStorage>1</largeStorage>
+        <multiSelect>0</multiSelect>
         <name>type</name>
         <number>5</number>
+        <picker>1</picker>
         <prettyName>Parameter type</prettyName>
-        <size>60</size>
+        <relationalStorage>0</relationalStorage>
+        <separator>|</separator>
+        <separators>|</separators>
+        <size>1</size>
         <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <values>Unknown|Wiki</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </type>
     </class>
     <property>
@@ -851,13 +881,24 @@
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
       <type>
+        <cache>0</cache>
+        <defaultValue>Unknown</defaultValue>
         <disabled>0</disabled>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <largeStorage>1</largeStorage>
+        <multiSelect>0</multiSelect>
         <name>type</name>
         <number>5</number>
+        <picker>1</picker>
         <prettyName>Parameter type</prettyName>
-        <size>60</size>
+        <relationalStorage>0</relationalStorage>
+        <separator>|</separator>
+        <separators>|</separators>
+        <size>1</size>
         <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <values>Unknown|Wiki</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </type>
     </class>
     <property>

--- a/application-diagram-ui/src/main/resources/Diagram/ResourceSelector/Browse.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/ResourceSelector/Browse.xml
@@ -236,7 +236,7 @@
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|doc.revision|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.session|request.url=Request URL|request.wiki=Request wiki|sheet|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>

--- a/application-diagram-ui/src/main/resources/Diagram/ResourceSelector/External.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/ResourceSelector/External.xml
@@ -199,7 +199,7 @@
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|doc.revision|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.session|request.url=Request URL|request.wiki=Request wiki|sheet|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>

--- a/application-diagram-ui/src/main/resources/Diagram/WebHome.xml
+++ b/application-diagram-ui/src/main/resources/Diagram/WebHome.xml
@@ -133,7 +133,7 @@
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|doc.revision|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.session|request.url=Request URL|request.wiki=Request wiki|sheet|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
   </build>
   <properties>
     <draw.io.version>24.5.5-3</draw.io.version>
-    <licensing.version>1.31.1</licensing.version>
+    <licensing.version>1.32</licensing.version>
   </properties>
   <modules>
     <module>application-diagram-api</module>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.xwiki.parent</groupId>
     <artifactId>xwikisas-parent-platform</artifactId>
-    <version>14.10-1</version>
+    <version>15.10</version>
   </parent>
   <groupId>com.xwiki.diagram</groupId>
   <artifactId>application-diagram-parent</artifactId>


### PR DESCRIPTION
Deleted a comment about updating a call to use a different constructor because the code was already using that constructor from the beginning. [https://jira.xwiki.org/browse/XCOMMONS-751](https://jira.xwiki.org/browse/XCOMMONS-751): Kept the comment about it since it is still not fixed. Replaced `addAttachment` with `setAttachment` since `addAttachment` is deprecated. Exported the diagram from a 15.10 instance.
Updated the Docker test class from AllITs to AllIT because the naming strategy changed between XWiki 14.10 and XWiki 15.10. Tested the diagram locally.